### PR TITLE
feat: Add Prequel/Sequel support and Title Language settings

### DIFF
--- a/app/src/main/java/eu/kanade/domain/SYDomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/SYDomainModule.kt
@@ -90,7 +90,7 @@ class SYDomainModule : InjektModule {
         addFactory { GetMergedEpisodesByAnimeId(get(), get()) }
         addFactory { GetSeasonsByAnimeId(get(), get()) }
         addFactory { DeleteSeason(get()) }
-        addFactory { DiscoverSeasons(get(), get()) }
+        addFactory { DiscoverSeasons(get(), get(), get()) }
 //        addFactory { InsertMergedReference(get()) }
         addFactory { UpdateMergedSettings(get()) }
         addFactory { DeleteByMergeId(get()) }

--- a/app/src/main/java/eu/kanade/presentation/anime/AnimeScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/AnimeScreen.kt
@@ -619,6 +619,11 @@ private fun AnimeScreenSmallImpl(
                                         onTagSearch = onTagSearch,
                                         onCopyTagToClipboard = onCopyTagToClipboard,
                                     )
+                                    
+                                    eu.kanade.presentation.anime.components.PrequelSequelBox(
+                                        relations = state.relations,
+                                        onRelationClick = { onSearch(it, true) }
+                                    )
                                 }
 
                                 // Cast Row — placed below tags
@@ -1110,6 +1115,11 @@ fun AnimeScreenLargeImpl(
                                         tagsProvider = { state.anime.genre },
                                         onTagSearch = onTagSearch,
                                         onCopyTagToClipboard = onCopyTagToClipboard,
+                                    )
+                                    
+                                    eu.kanade.presentation.anime.components.PrequelSequelBox(
+                                        relations = state.relations,
+                                        onRelationClick = { onSearch(it, true) }
                                     )
 
                                     // Cast Row — placed below tags

--- a/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonListItem.kt
@@ -3,6 +3,7 @@ package eu.kanade.presentation.anime.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import kotlin.math.roundToInt
 import tachiyomi.domain.anime.model.SeasonAnime
 import tachiyomi.domain.anime.model.SeasonDisplayMode
 import eu.kanade.presentation.library.components.AnimeComfortableGridItem
@@ -28,11 +29,22 @@ fun AnimeSeasonListItem(
     listItemModifier: Modifier = Modifier,
 ) {
     val itemAnime = item.seasonAnime.anime
-    val title = if (anime.seasonDisplayMode == Anime.SEASON_DISPLAY_MODE_NUMBER) {
-        stringResource(
-            MR.strings.display_mode_season,
-            formatEpisodeNumber(itemAnime.seasonNumber ?: 0.0),
-        )
+    val seasonNum = itemAnime.seasonNumber ?: 0.0
+    val title = if (anime.seasonDisplayMode == Anime.SEASON_DISPLAY_MODE_NUMBER || seasonNum > 0.0) {
+        val major = seasonNum.toInt()
+        val minor = ((seasonNum - major) * 100).roundToInt()
+        if (minor > 0) {
+            stringResource(
+                MR.strings.display_mode_season_part,
+                major.toString(),
+                minor.toString(),
+            )
+        } else {
+            stringResource(
+                MR.strings.display_mode_season,
+                major.toString(),
+            )
+        }
     } else {
         itemAnime.title
     }

--- a/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
@@ -179,7 +179,9 @@ private fun SeasonItem(
     val width = if (entry == AnimeCover.Panorama) 200.dp else 104.dp
 
     Column(
-        modifier = Modifier.width(width),
+        modifier = Modifier
+            .width(width)
+            .clickable(onClick = onClick),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         androidx.compose.foundation.layout.Box {
@@ -197,19 +199,21 @@ private fun SeasonItem(
                         .padding(4.dp),
                 ) {
                     Badge(
-                        text = "Current",
-                        color = MaterialTheme.colorScheme.secondary,
-                        textColor = MaterialTheme.colorScheme.onSecondary
+                        text = stringResource(MR.strings.selected),
+                        color = MaterialTheme.colorScheme.primary,
+                        textColor = MaterialTheme.colorScheme.onPrimary
                     )
                 }
             }
         }
         Text(
             text = seasonLabel,
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodySmall.copy(
+                fontWeight = if (season.isPrimary) FontWeight.Bold else FontWeight.Normal,
+            ),
             maxLines = 2,
             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = if (season.isPrimary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
@@ -160,10 +160,18 @@ private fun SeasonItem(
     } else {
         // MOVIES, OVAS, SPECIALS -> Show the Unique Name
         val fullTitle = season.anime.title
-        if (fullTitle.contains(":")) {
+        val subtitle = if (fullTitle.contains(":")) {
             fullTitle.substringAfter(":").trim()
         } else {
             fullTitle
+        }
+        
+        when (seasonNum) {
+            -2.0 -> if (subtitle.contains("Movie", ignoreCase = true)) subtitle else "Movie: $subtitle"
+            -3.0 -> if (subtitle.contains("OVA", ignoreCase = true)) subtitle else "OVA: $subtitle"
+            -4.0 -> if (subtitle.contains("ONA", ignoreCase = true)) subtitle else "ONA: $subtitle"
+            -5.0 -> if (subtitle.contains("Special", ignoreCase = true)) subtitle else "Special: $subtitle"
+            else -> subtitle
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import kotlin.math.roundToInt
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.library.components.AnimeComfortableGridItem
@@ -140,33 +141,29 @@ private fun SeasonItem(
     season: Season,
     onClick: () -> Unit,
 ) {
-    val seasonLabel = remember(season.seasonNumber, season.anime.title) {
+    val seasonNum = season.seasonNumber
+    val seasonLabel = if (seasonNum > 0.0) {
+        val major = seasonNum.toInt()
+        val minor = ((seasonNum - major) * 100).roundToInt()
+        if (minor > 0) {
+            stringResource(
+                MR.strings.display_mode_season_part,
+                major.toString(),
+                minor.toString(),
+            )
+        } else {
+            stringResource(
+                MR.strings.display_mode_season,
+                major.toString(),
+            )
+        }
+    } else {
+        // MOVIES, OVAS, SPECIALS -> Show the Unique Name
         val fullTitle = season.anime.title
-        
-        when {
-            // 1. STRICT TV SEASONS -> "Season X"
-            // This keeps your timeline clean as requested.
-            season.seasonNumber > 0 -> {
-                val num = if (season.seasonNumber % 1.0 == 0.0) 
-                    season.seasonNumber.toInt().toString() 
-                else 
-                    season.seasonNumber.toString()
-                "Season $num"
-            }
-            
-            // 2. MOVIES, OVAS, SPECIALS -> Show the Unique Name
-            else -> {
-                // Smart Clean: Remove the "Parent Name" part if it exists to avoid redundancy.
-                // But NEVER return a generic "Movie" label.
-                
-                // Heuristic: If there is a colon, take what's after the FIRST colon, not the last.
-                // This preserves complex subtitles like "Heaven's Feel - I. Presage Flower"
-                if (fullTitle.contains(":")) {
-                    fullTitle.substringAfter(":").trim()
-                } else {
-                    fullTitle // No colon? Show the full name (e.g., "Spirited Away")
-                }
-            }
+        if (fullTitle.contains(":")) {
+            fullTitle.substringAfter(":").trim()
+        } else {
+            fullTitle
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/AnimeSeasonSection.kt
@@ -1,5 +1,6 @@
 package eu.kanade.presentation.anime.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues

--- a/app/src/main/java/eu/kanade/presentation/anime/components/PrequelSequelBox.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/PrequelSequelBox.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.dp
 import tachiyomi.presentation.core.util.collectAsState
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.i18n.MR

--- a/app/src/main/java/eu/kanade/presentation/anime/components/PrequelSequelBox.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/PrequelSequelBox.kt
@@ -29,7 +29,8 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import tachiyomi.presentation.core.util.collectAsState
-import androidx.compose.runtime.collectAsState
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.i18n.MR
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import uy.kohesive.injekt.Injekt
@@ -60,7 +61,7 @@ fun PrequelSequelBox(
     ) {
         if (prequel != null) {
             RelationBanner(
-                relationName = "PREQUEL",
+                relationName = stringResource(MR.strings.relation_prequel),
                 edge = prequel,
                 preferredLanguage = preferredLanguage,
                 onRelationClick = onRelationClick,
@@ -69,7 +70,7 @@ fun PrequelSequelBox(
         }
         if (sequel != null) {
             RelationBanner(
-                relationName = "SEQUEL",
+                relationName = stringResource(MR.strings.relation_sequel),
                 edge = sequel,
                 preferredLanguage = preferredLanguage,
                 onRelationClick = onRelationClick,
@@ -98,14 +99,14 @@ private fun RelationBanner(
     Box(
         modifier = modifier
             .height(68.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onRelationClick(title) }
             .border(
                 width = 2.dp,
                 color = themeColor,
                 shape = RoundedCornerShape(12.dp)
             )
             .padding(4.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .clickable { onRelationClick(title) }
     ) {
         // Background Image
         AsyncImage(

--- a/app/src/main/java/eu/kanade/presentation/anime/components/PrequelSequelBox.kt
+++ b/app/src/main/java/eu/kanade/presentation/anime/components/PrequelSequelBox.kt
@@ -1,0 +1,195 @@
+package eu.kanade.presentation.anime.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import tachiyomi.presentation.core.util.collectAsState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import tachiyomi.domain.library.service.LibraryPreferences
+import coil3.compose.AsyncImage
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge
+
+@Composable
+fun PrequelSequelBox(
+    relations: List<ALRelationEdge>,
+    onRelationClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (relations.isEmpty()) return
+
+    val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+    val preferredLanguage by libraryPreferences.relationTitleLanguage().collectAsState()
+
+    val prequel = relations.find { it.relationType == "PREQUEL" }
+    val sequel = relations.find { it.relationType == "SEQUEL" }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        if (prequel != null) {
+            RelationBanner(
+                relationName = "PREQUEL",
+                edge = prequel,
+                preferredLanguage = preferredLanguage,
+                onRelationClick = onRelationClick,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        if (sequel != null) {
+            RelationBanner(
+                relationName = "SEQUEL",
+                edge = sequel,
+                preferredLanguage = preferredLanguage,
+                onRelationClick = onRelationClick,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RelationBanner(
+    relationName: String,
+    edge: ALRelationEdge,
+    preferredLanguage: String,
+    onRelationClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val themeColor = MaterialTheme.colorScheme.primary
+    
+    val title = when (preferredLanguage) {
+        "english" -> edge.node.title.english ?: edge.node.title.romaji ?: edge.node.title.userPreferred
+        "native" -> edge.node.title.native ?: edge.node.title.romaji ?: edge.node.title.userPreferred
+        else -> edge.node.title.romaji ?: edge.node.title.userPreferred
+    }
+
+    Box(
+        modifier = modifier
+            .height(68.dp)
+            .border(
+                width = 2.dp,
+                color = themeColor,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onRelationClick(title) }
+    ) {
+        // Background Image
+        AsyncImage(
+            model = edge.node.coverImage?.large,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        // Gradient Scrim
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Black.copy(alpha = 0.3f),
+                            Color.Black.copy(alpha = 0.8f)
+                        )
+                    )
+                )
+        )
+
+        // Text Content
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(4.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = relationName,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            )
+            Box(
+                modifier = Modifier
+                    .padding(bottom = 2.dp)
+                    .height(2.dp)
+                    .width(48.dp)
+                    .background(themeColor)
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = Color.White
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+private fun PrequelSequelBoxPreview() {
+    val dummyRelations = listOf(
+        eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge(
+            relationType = "PREQUEL",
+            node = eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationNode(
+                id = 1,
+                title = eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationTitle(userPreferred = "Dr. STONE"),
+                coverImage = null
+            )
+        ),
+        eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge(
+            relationType = "SEQUEL",
+            node = eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationNode(
+                id = 2,
+                title = eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationTitle(userPreferred = "Dr. STONE: New World"),
+                coverImage = null
+            )
+        )
+    )
+
+    MaterialTheme {
+        PrequelSequelBox(
+            relations = dummyRelations,
+            onRelationClick = {}
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -66,6 +66,7 @@ object SettingsLibraryScreen : SearchableSettings {
             getGlobalUpdateGroup(allAnimeCategories, libraryPreferences),
             getBehaviorGroup(libraryPreferences),
             getEpisodeSwipeActionsGroup(libraryPreferences),
+            getAnimeRelationsGroup(libraryPreferences),
         )
     }
 
@@ -337,6 +338,24 @@ object SettingsLibraryScreen : SearchableSettings {
                             stringResource(MR.strings.action_mark_as_seen),
                         LibraryPreferences.EpisodeSwipeAction.Download to
                             stringResource(MR.strings.action_download),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getAnimeRelationsGroup(libraryPreferences: LibraryPreferences): Preference.PreferenceGroup {
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_anime_relations),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.ListPreference(
+                    pref = libraryPreferences.relationTitleLanguage(),
+                    title = stringResource(MR.strings.pref_relation_title_language),
+                    entries = persistentMapOf(
+                        "romaji" to stringResource(MR.strings.romaji),
+                        "english" to stringResource(MR.strings.english),
+                        "native" to stringResource(MR.strings.native_title),
                     ),
                 ),
             ),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -220,6 +220,10 @@ class Anilist(id: Long) :
         return track
     }
 
+    suspend fun getAnimeRelations(trackId: Long): List<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> {
+        return api.getRelations(trackId.toInt())
+    }
+
     override suspend fun login(username: String, password: String) = login(password)
 
     suspend fun login(token: String) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -250,6 +250,54 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return findLibAnime(track, userId) ?: throw Exception("Could not find anime")
     }
 
+    suspend fun getRelations(mediaId: Int): List<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> {
+        return withIOContext {
+            val query = """
+            |query (${'$'}mediaId: Int!) {
+                |Media(id: ${'$'}mediaId, type: ANIME) {
+                    |relations {
+                        |edges {
+                            |relationType(version: 2)
+                            |node {
+                                |id
+                                |title {
+                                    |userPreferred
+                                    |romaji
+                                    |english
+                                    |native
+                                |}
+                                |coverImage {
+                                    |large
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            |}
+            |
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("mediaId", mediaId)
+                }
+            }
+            with(json) {
+                client.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationResult>()
+                    .data.Media?.relations?.edges?.filter { 
+                        it.relationType == "PREQUEL" || it.relationType == "SEQUEL" 
+                    } ?: emptyList()
+            }
+        }
+    }
+
     fun createOAuth(token: String): ALOAuth {
         return ALOAuth(token, "Bearer", System.currentTimeMillis() + 31536000000, 31536000000)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALRelationResult.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALRelationResult.kt
@@ -1,0 +1,49 @@
+package eu.kanade.tachiyomi.data.track.anilist.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ALRelationResult(
+    val data: ALRelationData
+)
+
+@Serializable
+data class ALRelationData(
+    val Media: ALRelationMedia? = null
+)
+
+@Serializable
+data class ALRelationMedia(
+    val relations: ALRelationConnection? = null
+)
+
+@Serializable
+data class ALRelationConnection(
+    val edges: List<ALRelationEdge>? = null
+)
+
+@Serializable
+data class ALRelationEdge(
+    val relationType: String,
+    val node: ALRelationNode
+)
+
+@Serializable
+data class ALRelationNode(
+    val id: Int,
+    val title: ALRelationTitle,
+    val coverImage: ALRelationCoverImage? = null
+)
+
+@Serializable
+data class ALRelationTitle(
+    val userPreferred: String,
+    val romaji: String? = null,
+    val english: String? = null,
+    val native: String? = null
+)
+
+@Serializable
+data class ALRelationCoverImage(
+    val large: String? = null
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -252,6 +252,7 @@ class AnimeScreenModel(
         anime: Anime = this.anime,
         episodes: List<EpisodeList.Item> = this.episodes,
         trackItems: List<TrackItem> = this.trackItems,
+        relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = this.relations,
         suggestionSections: ImmutableList<SuggestionSection> = this.suggestionSections,
         isSuggestionsLoading: Boolean = this.isSuggestionsLoading,
         dialog: Dialog? = this.dialog,
@@ -493,6 +494,7 @@ class AnimeScreenModel(
             episodeListItems = episodeListItems,
             missingEpisodeCount = missingEpisodeCount,
             trackItems = trackItems.toImmutableList(),
+            relations = relations,
             suggestionSections = suggestionSections,
             dialog = dialog,
             isRefreshingData = isRefreshingData,
@@ -1797,6 +1799,20 @@ class AnimeScreenModel(
             }.distinctUntilChanged().collectLatest { trackItems -> 
                 updateSuccessState { it.copySuccess(trackItems = trackItems) }
                 updateAiringTime(anime, trackItems, manualFetch = false) 
+                
+                val anilistTrackItem = trackItems.find { it.tracker is eu.kanade.tachiyomi.data.track.anilist.Anilist && it.track != null }
+                if (anilistTrackItem != null) {
+                    val tracker = anilistTrackItem.tracker as eu.kanade.tachiyomi.data.track.anilist.Anilist
+                    val remoteId = anilistTrackItem.track!!.remoteId
+                    screenModelScope.launchIO {
+                        try {
+                            val relations = tracker.getAnimeRelations(remoteId)
+                            updateSuccessState { it.copySuccess(relations = relations.toImmutableList()) }
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR, e)
+                        }
+                    }
+                }
             }
         }
     }
@@ -1985,6 +2001,7 @@ class AnimeScreenModel(
             val dialog: Dialog? = null,
             val hasPromptedToAddBefore: Boolean = false,
             val trackItems: ImmutableList<TrackItem> = persistentListOf(),
+            val relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = persistentListOf(),
             val nextAiringEpisode: Pair<Int, Long> = Pair(anime.nextEpisodeToAir, anime.nextEpisodeAiringAt),
             val suggestions: ImmutableList<Anime> = persistentListOf(),
             val isSuggestionsLoading: Boolean = true,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -498,6 +498,7 @@ class AnimeScreenModel(
             trackItems = trackItems.toImmutableList(),
             relations = relations,
             hasFetchedRelations = hasFetchedRelations,
+            hasFetchedRelations = hasFetchedRelations,
             suggestionSections = suggestionSections,
             dialog = dialog,
             isRefreshingData = isRefreshingData,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -2012,6 +2012,7 @@ class AnimeScreenModel(
             val trackItems: ImmutableList<TrackItem> = persistentListOf(),
             val relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = persistentListOf(),
             val hasFetchedRelations: Boolean = false,
+            val hasFetchedRelations: Boolean = false,
             val nextAiringEpisode: Pair<Int, Long> = Pair(anime.nextEpisodeToAir, anime.nextEpisodeAiringAt),
             val suggestions: ImmutableList<Anime> = persistentListOf(),
             val isSuggestionsLoading: Boolean = true,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -588,10 +588,16 @@ class AnimeScreenModel(
                     ?.items.orEmpty()
             }.distinctUntilChanged()
 
+            val extensionManager = Injekt.get<eu.kanade.tachiyomi.extension.ExtensionManager>()
+            val installedExtensions = extensionManager.installedExtensionsFlow.value
+            val extension = installedExtensions.find { ext -> ext.sources.any { it.id == initialAnime.source } }
+            val isHierarchicalSupported = (extension?.libVersion ?: 0.0) >= 16.0
+            val useHierarchicalSeasons = libraryPreferences.useHierarchicalSeasons().get() && isHierarchicalSupported
+
             combine(
                 getAnimeAndEpisodesAndSeasons.subscribe(
                     id = animeId,
-                    useHierarchicalSeasons = libraryPreferences.useHierarchicalSeasons().get(),
+                    useHierarchicalSeasons = useHierarchicalSeasons,
                     virtualSeasonsFlow = virtualSeasonsFlow,
                 ).distinctUntilChanged(),
                 downloadCache.changes,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -2010,7 +2010,6 @@ class AnimeScreenModel(
             val trackItems: ImmutableList<TrackItem> = persistentListOf(),
             val relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = persistentListOf(),
             val hasFetchedRelations: Boolean = false,
-            val hasFetchedRelations: Boolean = false,
             val nextAiringEpisode: Pair<Int, Long> = Pair(anime.nextEpisodeToAir, anime.nextEpisodeAiringAt),
             val suggestions: ImmutableList<Anime> = persistentListOf(),
             val isSuggestionsLoading: Boolean = true,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -497,7 +497,6 @@ class AnimeScreenModel(
             trackItems = trackItems.toImmutableList(),
             relations = relations,
             hasFetchedRelations = hasFetchedRelations,
-            hasFetchedRelations = hasFetchedRelations,
             suggestionSections = suggestionSections,
             dialog = dialog,
             isRefreshingData = isRefreshingData,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -591,7 +591,7 @@ class AnimeScreenModel(
             val extensionManager = Injekt.get<eu.kanade.tachiyomi.extension.ExtensionManager>()
             val installedExtensions = extensionManager.installedExtensionsFlow.value
             val extension = installedExtensions.find { ext -> ext.sources.any { it.id == initialAnime.source } }
-            val isHierarchicalSupported = (extension?.libVersion ?: 0.0) >= 16.0
+            val isHierarchicalSupported = (extension?.versionCode ?: 0L) >= 16L
             val useHierarchicalSeasons = libraryPreferences.useHierarchicalSeasons().get() && isHierarchicalSupported
 
             combine(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -253,6 +253,7 @@ class AnimeScreenModel(
         episodes: List<EpisodeList.Item> = this.episodes,
         trackItems: List<TrackItem> = this.trackItems,
         relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = this.relations,
+        hasFetchedRelations: Boolean = this.hasFetchedRelations,
         suggestionSections: ImmutableList<SuggestionSection> = this.suggestionSections,
         isSuggestionsLoading: Boolean = this.isSuggestionsLoading,
         dialog: Dialog? = this.dialog,
@@ -495,6 +496,7 @@ class AnimeScreenModel(
             missingEpisodeCount = missingEpisodeCount,
             trackItems = trackItems.toImmutableList(),
             relations = relations,
+            hasFetchedRelations = hasFetchedRelations,
             suggestionSections = suggestionSections,
             dialog = dialog,
             isRefreshingData = isRefreshingData,
@@ -1804,12 +1806,17 @@ class AnimeScreenModel(
                 if (anilistTrackItem != null) {
                     val tracker = anilistTrackItem.tracker as eu.kanade.tachiyomi.data.track.anilist.Anilist
                     val remoteId = anilistTrackItem.track!!.remoteId
-                    screenModelScope.launchIO {
-                        try {
-                            val relations = tracker.getAnimeRelations(remoteId)
-                            updateSuccessState { it.copySuccess(relations = relations.toImmutableList()) }
-                        } catch (e: Exception) {
-                            logcat(LogPriority.ERROR, e)
+                    val alreadyFetched = successState?.hasFetchedRelations == true
+                    if (!alreadyFetched) {
+                        updateSuccessState { it.copySuccess(hasFetchedRelations = true) }
+                        screenModelScope.launchIO {
+                            try {
+                                val relations = tracker.getAnimeRelations(remoteId)
+                                updateSuccessState { it.copySuccess(relations = relations.toImmutableList()) }
+                            } catch (e: Exception) {
+                                logcat(LogPriority.ERROR, e)
+                                updateSuccessState { it.copySuccess(hasFetchedRelations = false) }
+                            }
                         }
                     }
                 }
@@ -2002,6 +2009,7 @@ class AnimeScreenModel(
             val hasPromptedToAddBefore: Boolean = false,
             val trackItems: ImmutableList<TrackItem> = persistentListOf(),
             val relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = persistentListOf(),
+            val hasFetchedRelations: Boolean = false,
             val nextAiringEpisode: Pair<Int, Long> = Pair(anime.nextEpisodeToAir, anime.nextEpisodeAiringAt),
             val suggestions: ImmutableList<Anime> = persistentListOf(),
             val isSuggestionsLoading: Boolean = true,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -254,6 +254,7 @@ class AnimeScreenModel(
         trackItems: List<TrackItem> = this.trackItems,
         relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = this.relations,
         hasFetchedRelations: Boolean = this.hasFetchedRelations,
+        hasFetchedRelations: Boolean = this.hasFetchedRelations,
         suggestionSections: ImmutableList<SuggestionSection> = this.suggestionSections,
         isSuggestionsLoading: Boolean = this.isSuggestionsLoading,
         dialog: Dialog? = this.dialog,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreenModel.kt
@@ -254,7 +254,6 @@ class AnimeScreenModel(
         trackItems: List<TrackItem> = this.trackItems,
         relations: ImmutableList<eu.kanade.tachiyomi.data.track.anilist.dto.ALRelationEdge> = this.relations,
         hasFetchedRelations: Boolean = this.hasFetchedRelations,
-        hasFetchedRelations: Boolean = this.hasFetchedRelations,
         suggestionSections: ImmutableList<SuggestionSection> = this.suggestionSections,
         isSuggestionsLoading: Boolean = this.isSuggestionsLoading,
         dialog: Dialog? = this.dialog,

--- a/data/src/main/sqldelight/tachiyomi/data/migrations/143.sqm
+++ b/data/src/main/sqldelight/tachiyomi/data/migrations/143.sqm
@@ -1,0 +1,173 @@
+DROP VIEW IF EXISTS episodestatsView;
+CREATE VIEW episodestatsView AS
+SELECT
+    episodes.anime_id,
+    count(*) AS total,
+    sum(seen) AS seenCount,
+    coalesce(max(episodes.date_upload), 0) AS latestUpload,
+    coalesce(max(episodes.date_fetch), 0) AS fetchedAt,
+    sum(episodes.bookmark) AS bookmarkCount,
+    sum(episodes.fillermark) AS fillermarkCount
+FROM episodes
+LEFT JOIN excluded_scanlators
+    ON episodes.anime_id = excluded_scanlators.anime_id
+    AND episodes.scanlator = excluded_scanlators.scanlator
+WHERE excluded_scanlators.scanlator IS NULL
+GROUP BY episodes.anime_id;
+
+DROP VIEW IF EXISTS historystatsView;
+CREATE VIEW historystatsView AS
+SELECT
+    episodes.anime_id,
+    max(h.last_seen) AS lastSeen
+FROM episodes
+LEFT JOIN history AS h ON episodes._id = h.episode_id
+GROUP BY episodes.anime_id;
+
+DROP VIEW IF EXISTS animeseasonstatsView;
+CREATE VIEW animeseasonstatsView AS
+SELECT
+    season.parent_id,
+    count(*) AS child_count,
+    sum(CASE WHEN season.fetch_type = 1 AND
+                 coalesce(ES.total, 0) = coalesce(ES.seenCount, 0)
+            THEN 1 ELSE 0 END) AS fully_seen_seasons,
+    max(coalesce(ES.latestUpload, 0)) AS max_latest_upload,
+    max(coalesce(ES.fetchedAt, 0)) AS max_fetched_at,
+    max(coalesce(HS.lastSeen, 0)) AS max_last_seen,
+    sum(coalesce(ES.bookmarkCount, 0)) AS total_bookmarks,
+    sum(coalesce(ES.fillermarkCount, 0)) AS total_fillermarks
+FROM animes season
+LEFT JOIN episodestatsView ES ON season._id = ES.anime_id
+LEFT JOIN historystatsView HS ON season._id = HS.anime_id
+WHERE season.parent_id IS NOT NULL
+GROUP BY season.parent_id;
+
+DROP VIEW IF EXISTS libraryView;
+CREATE VIEW libraryView AS
+SELECT
+    A.*,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.total, 0)
+        WHEN 0 THEN coalesce(ASS.child_count, 0)
+    END AS totalCount,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.seenCount, 0)
+        WHEN 0 THEN coalesce(ASS.fully_seen_seasons, 0)
+    END AS seenCount,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.latestUpload, 0)
+        WHEN 0 THEN coalesce(ASS.max_latest_upload, 0)
+    END AS latestUpload,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.fetchedAt, 0)
+        WHEN 0 THEN coalesce(ASS.max_fetched_at, 0)
+    END AS episodeFetchedAt,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(HS.lastSeen, 0)
+        WHEN 0 THEN coalesce(ASS.max_last_seen, 0)
+    END AS lastSeen,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.bookmarkCount, 0)
+        WHEN 0 THEN coalesce(ASS.total_bookmarks, 0)
+    END AS bookmarkCount,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.fillermarkCount, 0)
+        WHEN 0 THEN coalesce(ASS.total_fillermarks, 0)
+    END AS fillermarkCount,
+    coalesce(AC.category_id, 0) AS category
+FROM animes AS A
+LEFT JOIN episodestatsView AS ES
+ON A._id = ES.anime_id
+LEFT JOIN historystatsView AS HS
+ON A._id = HS.anime_id
+LEFT JOIN animeseasonstatsView AS ASS
+ON A._id = ASS.parent_id
+LEFT JOIN animes_categories AS AC
+ON AC.anime_id = A._id
+WHERE A.source <> 6969
+UNION
+SELECT
+    A.*,
+    coalesce(EP.total, 0) AS totalCount,
+    coalesce(EP.seenCount, 0) AS seenCount,
+    coalesce(EP.latestUpload, 0) AS latestUpload,
+    coalesce(EP.fetchedAt, 0) AS episodeFetchedAt,
+    coalesce(EP.lastSeen, 0) AS lastSeen,
+    coalesce(EP.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(EP.fillermarkCount, 0) AS fillermarkCount,
+    coalesce(AC.category_id, 0) AS category
+FROM animes A
+LEFT JOIN (
+    SELECT merged.anime_id,merged.merge_id
+    FROM merged
+    GROUP BY merged.merge_id
+) AS ME
+ON ME.merge_id = A._id
+LEFT JOIN(
+    SELECT
+        ME.merge_id,
+        count(*) AS total,
+        sum(seen) AS seenCount,
+        coalesce(max(episodes.date_upload), 0) AS latestUpload,
+        coalesce(max(history.last_seen), 0) AS lastSeen,
+        coalesce(max(episodes.date_fetch), 0) AS fetchedAt,
+        sum(episodes.bookmark) AS bookmarkCount,
+        excluded_scanlators.scanlator AS ex_scanlator,
+        sum(episodes.fillermark) AS fillermarkCount
+    FROM episodes
+    LEFT JOIN excluded_scanlators
+    ON episodes.anime_id = excluded_scanlators.anime_id
+    AND episodes.scanlator = excluded_scanlators.scanlator
+    LEFT JOIN history
+    ON episodes._id = history.episode_id
+    LEFT JOIN merged ME
+    ON ME.anime_id = episodes.anime_id
+    WHERE ex_scanlator IS NULL
+    GROUP BY ME.merge_id
+) AS EP
+ON A._id = EP.merge_id
+LEFT JOIN animes_categories AS AC
+ON AC.anime_id = A._id
+WHERE A.source = 6969;
+
+DROP VIEW IF EXISTS animeseasonsView;
+CREATE VIEW animeseasonsView AS
+SELECT
+    A.*,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.total, 0)
+        WHEN 0 THEN coalesce(ASS.child_count, 0)
+    END AS totalCount,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.seenCount, 0)
+        WHEN 0 THEN coalesce(ASS.fully_seen_seasons, 0)
+    END AS seenCount,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.latestUpload, 0)
+        WHEN 0 THEN coalesce(ASS.max_latest_upload, 0)
+    END AS latestUpload,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.fetchedAt, 0)
+        WHEN 0 THEN coalesce(ASS.max_fetched_at, 0)
+    END AS episodeFetchedAt,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(HS.lastSeen, 0)
+        WHEN 0 THEN coalesce(ASS.max_last_seen, 0)
+    END AS lastSeen,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.bookmarkCount, 0)
+        WHEN 0 THEN coalesce(ASS.total_bookmarks, 0)
+    END AS bookmarkCount,
+    CASE A.fetch_type
+        WHEN 1 THEN coalesce(ES.fillermarkCount, 0)
+        WHEN 0 THEN coalesce(ASS.total_fillermarks, 0)
+    END AS fillermarkCount
+FROM animes AS A
+LEFT JOIN episodestatsView AS ES
+ON A._id = ES.anime_id
+LEFT JOIN historystatsView AS HS
+ON A._id = HS.anime_id
+LEFT JOIN animeseasonstatsView AS ASS
+ON A._id = ASS.parent_id
+WHERE A.parent_id IS NOT NULL;

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
@@ -16,27 +16,34 @@ class DiscoverSeasons(
         
         val originalFullTitle = anime.title
         val rootTitle = SeasonRecognition.getRootTitle(originalFullTitle)
+        val ogTitle = anime.ogTitle.takeIf { it.isNotBlank() } ?: originalFullTitle
         
         if (rootTitle.length < 3) return emptyList()
         
         return try {
-            val searchResult = source.getSearchAnime(1, rootTitle, source.getFilterList())
+            // Try searching for root title and original title for better coverage
+            val searchQueries = listOf(rootTitle, ogTitle).distinctBy { SeasonRecognition.getAlphanumeric(it) }
+            val allResults = searchQueries.flatMap { query ->
+                source.getSearchAnime(1, query, source.getFilterList()).animes
+            }.distinctBy { it.url.trimEnd('/') }
             
             // 1. Strict Word Coverage Lock
             val originalWordSet = SeasonRecognition.getWordSet(rootTitle)
             if (originalWordSet.isEmpty()) return emptyList()
 
-            val candidates = searchResult.animes.filter { sAnime ->
+            val candidates = allResults.filter { sAnime ->
                 val candidateFullTitle = sAnime.title
                 
                 // NO-TOLERANCE FILTERS
                 if (SeasonRecognition.isUnrelated(originalFullTitle, candidateFullTitle)) return@filter false
                 
-                // 1. Signature Word Coverage Lock
+                // 1. Signature Word Coverage Lock (Alphanumeric normalization)
                 val originalSignature = SeasonRecognition.getSignatureWords(rootTitle)
+                val candidateAlpha = SeasonRecognition.getAlphanumeric(candidateFullTitle)
+                
                 if (originalSignature.isNotEmpty()) {
                     val allWordsContained = originalSignature.all { sigWord ->
-                        candidateFullTitle.contains(sigWord, ignoreCase = true)
+                        candidateAlpha.contains(SeasonRecognition.getAlphanumeric(sigWord))
                     }
                     if (!allWordsContained) return@filter false
                 }
@@ -47,23 +54,22 @@ class DiscoverSeasons(
                 val isAcronym = SeasonRecognition.isAcronymMatch(rootTitle, candidateFullTitle)
                 
                 // Final Decision: Must pass signature check AND one of the similarity checks
-                // Tightened thresholds from 0.4 to 0.7 to prevent random matches
-                if (dice < 0.7 && tokenSort < 0.7 && !isAcronym && !candidateFullTitle.contains(rootTitle, ignoreCase = true)) {
+                // Relaxed slightly to 0.6 to allow space-less matches (Dandadan)
+                if (dice < 0.6 && tokenSort < 0.6 && !isAcronym && !candidateAlpha.contains(SeasonRecognition.getAlphanumeric(rootTitle))) {
                     return@filter false
                 }
 
                 // 3. Main Season Lock: Allow main seasons, movies, and OVAs.
-                // Exclude generic specials (-5.0) to keep the seasons bar focused.
                 val seasonNum = SeasonRecognition.parseSeasonNumber(anime.title, candidateFullTitle)
                 if (seasonNum < -4.0) return@filter false
                 
                 true
-            }.take(10)
+            }.take(15)
 
             val verified = candidates
                 .filter { it.url.trimEnd('/') != anime.url.trimEnd('/') } // Filter out the current anime
                 .map { it.toDomainAnime(anime.source) }
-                .distinctBy { it.url.trimEnd('/') } // Deduplicate by URL instead of placeholder ID
+                .distinctBy { it.url.trimEnd('/') }
 
             verified.sortedBy { sAnime ->
                 SeasonRecognition.parseSeasonNumber(anime.title, sAnime.title)

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
@@ -59,9 +59,9 @@ class DiscoverSeasons(
                     return@filter false
                 }
 
-                // 3. Main Season Lock: Allow main seasons, movies, and OVAs.
+                // 3. Main Season Lock: Allow seasons, movies, OVAs, and Specials.
                 val seasonNum = SeasonRecognition.parseSeasonNumber(anime.title, candidateFullTitle)
-                if (seasonNum < -4.0) return@filter false
+                if (seasonNum < -5.0) return@filter false
                 
                 true
             }.take(15)

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
@@ -51,9 +51,10 @@ class DiscoverSeasons(
                     return@filter false
                 }
 
-                // 3. Main Season Lock: Remove anything identified as a Movie, OVA, or Special
+                // 3. Main Season Lock: Allow main seasons, movies, and OVAs.
+                // Exclude generic specials (-5.0) to keep the seasons bar focused.
                 val seasonNum = SeasonRecognition.parseSeasonNumber(anime.title, candidateFullTitle)
-                if (seasonNum < 1.0) return@filter false
+                if (seasonNum < -4.0) return@filter false
                 
                 true
             }.take(10)

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
@@ -7,9 +7,13 @@ import tachiyomi.domain.anime.repository.AnimeRepository
 import tachiyomi.domain.anime.service.SeasonRecognition
 import tachiyomi.domain.source.service.SourceManager
 
+import kotlinx.coroutines.flow.firstOrNull
+import tachiyomi.domain.source.interactor.GetRelatedAnime
+
 class DiscoverSeasons(
     private val sourceManager: SourceManager,
     private val animeRepository: AnimeRepository,
+    private val getRelatedAnime: GetRelatedAnime,
 ) {
     suspend fun await(anime: Anime): List<Anime> {
         val source = sourceManager.get(anime.source) as? AnimeCatalogueSource ?: return emptyList()
@@ -21,19 +25,31 @@ class DiscoverSeasons(
         if (rootTitle.length < 3) return emptyList()
         
         return try {
-            // Try searching for root title and original title for better coverage
+            // 1. Get explicit relations from the extension (Highest Confidence)
+            val explicitRelations = getRelatedAnime.subscribe(anime).firstOrNull()?.second.orEmpty()
+                .map { it.toDomainAnime(anime.source) }
+
+            // 2. Try searching for root title and original title for better coverage
             val searchQueries = listOf(rootTitle, ogTitle).distinctBy { SeasonRecognition.getAlphanumeric(it) }
-            val allResults = searchQueries.flatMap { query ->
+            val searchResults = searchQueries.flatMap { query ->
                 source.getSearchAnime(1, query, source.getFilterList()).animes
-            }.distinctBy { it.url.trimEnd('/') }
+            }.map { it.toDomainAnime(anime.source) }
             
-            // 1. Strict Word Coverage Lock
+            // 3. Pool and Filter
+            val allResults = (explicitRelations + searchResults)
+                .filter { it.url.trimEnd('/') != anime.url.trimEnd('/') } // Filter out the current anime
+                .distinctBy { it.url.trimEnd('/') }
+            
             val originalWordSet = SeasonRecognition.getWordSet(rootTitle)
             if (originalWordSet.isEmpty()) return emptyList()
 
             val candidates = allResults.filter { sAnime ->
                 val candidateFullTitle = sAnime.title
                 
+                // If it came from explicit relations, we trust it more
+                val isExplicit = explicitRelations.any { it.url == sAnime.url }
+                if (isExplicit) return@filter true
+
                 // NO-TOLERANCE FILTERS
                 if (SeasonRecognition.isUnrelated(originalFullTitle, candidateFullTitle)) return@filter false
                 
@@ -54,7 +70,6 @@ class DiscoverSeasons(
                 val isAcronym = SeasonRecognition.isAcronymMatch(rootTitle, candidateFullTitle)
                 
                 // Final Decision: Must pass signature check AND one of the similarity checks
-                // Relaxed slightly to 0.6 to allow space-less matches (Dandadan)
                 if (dice < 0.6 && tokenSort < 0.6 && !isAcronym && !candidateAlpha.contains(SeasonRecognition.getAlphanumeric(rootTitle))) {
                     return@filter false
                 }
@@ -64,14 +79,9 @@ class DiscoverSeasons(
                 if (seasonNum < -5.0) return@filter false
                 
                 true
-            }.take(15)
+            }.take(20)
 
-            val verified = candidates
-                .filter { it.url.trimEnd('/') != anime.url.trimEnd('/') } // Filter out the current anime
-                .map { it.toDomainAnime(anime.source) }
-                .distinctBy { it.url.trimEnd('/') }
-
-            verified.sortedBy { sAnime ->
+            candidates.sortedBy { sAnime ->
                 SeasonRecognition.parseSeasonNumber(anime.title, sAnime.title)
             }
         } catch (e: Exception) {

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/DiscoverSeasons.kt
@@ -47,7 +47,8 @@ class DiscoverSeasons(
                 val isAcronym = SeasonRecognition.isAcronymMatch(rootTitle, candidateFullTitle)
                 
                 // Final Decision: Must pass signature check AND one of the similarity checks
-                if (dice < 0.4 && tokenSort < 0.4 && !isAcronym && !candidateFullTitle.contains(rootTitle, ignoreCase = true)) {
+                // Tightened thresholds from 0.4 to 0.7 to prevent random matches
+                if (dice < 0.7 && tokenSort < 0.7 && !isAcronym && !candidateFullTitle.contains(rootTitle, ignoreCase = true)) {
                     return@filter false
                 }
 

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
@@ -25,14 +25,19 @@ class GetAnimeWithEpisodesAndSeasons(
         virtualSeasonsFlow: Flow<List<Anime>>? = null,
     ): Flow<Triple<Anime, List<Episode>, List<SeasonAnime>>> {
         return animeRepository.getAnimeByIdAsFlow(id).flatMapLatest { anime ->
-            val parentId = anime.parentId ?: id
-            val seasonsFlow = if (useHierarchicalSeasons) {
-                animeRepository.getAnimeSeasonsByIdAsFlow(parentId)
-            } else {
-                getSeasonsByAnimeId.subscribe(id, virtualSeasonsFlow).map { seasonsList ->
-                    seasonsList.map {
+            val parentId = if (useHierarchicalSeasons) (anime.parentId ?: id) else id
+            
+            val dbSeasonsFlow = animeRepository.getAnimeSeasonsByIdAsFlow(parentId)
+            val seasonsListFlow = getSeasonsByAnimeId.subscribe(id, virtualSeasonsFlow, useHierarchicalSeasons)
+
+            val combinedSeasonsFlow = combine(dbSeasonsFlow, seasonsListFlow) { dbSeasons, seasonsList ->
+                seasonsList.map { season ->
+                    val dbSeason = dbSeasons.find { it.anime.id == season.anime.id }
+                    if (dbSeason != null) {
+                        dbSeason
+                    } else {
                         SeasonAnime(
-                            anime = it.anime,
+                            anime = season.anime,
                             totalCount = 0,
                             seenCount = 0,
                             bookmarkCount = 0,
@@ -47,7 +52,7 @@ class GetAnimeWithEpisodesAndSeasons(
 
             combine(
                 episodeRepository.getEpisodeByAnimeIdAsFlow(id, applyScanlatorFilter),
-                seasonsFlow,
+                combinedSeasonsFlow,
                 getCustomAnimeInfo.subscribe(id),
             ) { episodes, seasons, customInfo ->
                 Triple(anime.copy(customAnimeInfo = customInfo), episodes, seasons)
@@ -63,8 +68,28 @@ class GetAnimeWithEpisodesAndSeasons(
         return episodeRepository.getEpisodeByAnimeId(id, applyScanlatorFilter)
     }
 
-    suspend fun awaitSeasons(id: Long): List<SeasonAnime> {
+    suspend fun awaitSeasons(id: Long, useHierarchicalSeasons: Boolean = true): List<SeasonAnime> {
         val anime = animeRepository.getAnimeById(id)
-        return animeRepository.getAnimeSeasonsById(anime.parentId ?: id)
+        val parentId = if (useHierarchicalSeasons) (anime.parentId ?: id) else id
+        val dbSeasons = animeRepository.getAnimeSeasonsById(parentId)
+        val seasonsList = getSeasonsByAnimeId.await(id, emptyList(), useHierarchicalSeasons)
+
+        return seasonsList.map { season ->
+            val dbSeason = dbSeasons.find { it.anime.id == season.anime.id }
+            if (dbSeason != null) {
+                dbSeason
+            } else {
+                SeasonAnime(
+                    anime = season.anime,
+                    totalCount = 0,
+                    seenCount = 0,
+                    bookmarkCount = 0,
+                    fillermarkCount = 0,
+                    latestUpload = 0,
+                    fetchedAt = 0,
+                    lastSeen = 0,
+                )
+            }
+        }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
@@ -18,6 +18,17 @@ class GetAnimeWithEpisodesAndSeasons(
     private val getSeasonsByAnimeId: GetSeasonsByAnimeId,
 ) {
 
+    private fun isHierarchicalSupported(sourceId: Long): Boolean {
+        return try {
+            val extensionManager = uy.kohesive.injekt.Injekt.get<eu.kanade.tachiyomi.extension.ExtensionManager>()
+            val installedExtensions = extensionManager.installedExtensionsFlow.value
+            val extension = installedExtensions.find { ext -> ext.sources.any { it.id == sourceId } }
+            (extension?.libVersion ?: 0.0) >= 16.0
+        } catch (e: Exception) {
+            false
+        }
+    }
+
     suspend fun subscribe(
         id: Long,
         applyScanlatorFilter: Boolean = false,
@@ -25,10 +36,13 @@ class GetAnimeWithEpisodesAndSeasons(
         virtualSeasonsFlow: Flow<List<Anime>>? = null,
     ): Flow<Triple<Anime, List<Episode>, List<SeasonAnime>>> {
         return animeRepository.getAnimeByIdAsFlow(id).flatMapLatest { anime ->
-            val parentId = if (useHierarchicalSeasons) (anime.parentId ?: id) else id
+            val isHierarchicalSupported = isHierarchicalSupported(anime.source)
+            val effectiveHierarchical = useHierarchicalSeasons && isHierarchicalSupported
+            
+            val parentId = if (effectiveHierarchical) (anime.parentId ?: id) else id
             
             val dbSeasonsFlow = animeRepository.getAnimeSeasonsByIdAsFlow(parentId)
-            val seasonsListFlow = getSeasonsByAnimeId.subscribe(id, virtualSeasonsFlow, useHierarchicalSeasons)
+            val seasonsListFlow = getSeasonsByAnimeId.subscribe(id, virtualSeasonsFlow, effectiveHierarchical)
 
             val combinedSeasonsFlow = combine(dbSeasonsFlow, seasonsListFlow) { dbSeasons, seasonsList ->
                 seasonsList.map { season ->
@@ -70,9 +84,12 @@ class GetAnimeWithEpisodesAndSeasons(
 
     suspend fun awaitSeasons(id: Long, useHierarchicalSeasons: Boolean = true): List<SeasonAnime> {
         val anime = animeRepository.getAnimeById(id)
-        val parentId = if (useHierarchicalSeasons) (anime.parentId ?: id) else id
+        val isHierarchicalSupported = isHierarchicalSupported(anime.source)
+        val effectiveHierarchical = useHierarchicalSeasons && isHierarchicalSupported
+        
+        val parentId = if (effectiveHierarchical) (anime.parentId ?: id) else id
         val dbSeasons = animeRepository.getAnimeSeasonsById(parentId)
-        val seasonsList = getSeasonsByAnimeId.await(id, emptyList(), useHierarchicalSeasons)
+        val seasonsList = getSeasonsByAnimeId.await(id, emptyList(), effectiveHierarchical)
 
         return seasonsList.map { season ->
             val dbSeason = dbSeasons.find { it.anime.id == season.anime.id }

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
@@ -34,10 +34,10 @@ class GetAnimeWithEpisodesAndSeasons(
                 seasonsList.map { season ->
                     val dbSeason = dbSeasons.find { it.anime.id == season.anime.id }
                     if (dbSeason != null) {
-                        dbSeason
+                        dbSeason.copy(anime = dbSeason.anime.copy(seasonNumber = season.seasonNumber))
                     } else {
                         SeasonAnime(
-                            anime = season.anime,
+                            anime = season.anime.copy(seasonNumber = season.seasonNumber),
                             totalCount = 0,
                             seenCount = 0,
                             bookmarkCount = 0,
@@ -77,10 +77,10 @@ class GetAnimeWithEpisodesAndSeasons(
         return seasonsList.map { season ->
             val dbSeason = dbSeasons.find { it.anime.id == season.anime.id }
             if (dbSeason != null) {
-                dbSeason
+                dbSeason.copy(anime = dbSeason.anime.copy(seasonNumber = season.seasonNumber))
             } else {
                 SeasonAnime(
-                    anime = season.anime,
+                    anime = season.anime.copy(seasonNumber = season.seasonNumber),
                     totalCount = 0,
                     seenCount = 0,
                     bookmarkCount = 0,

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/GetAnimeWithEpisodesAndSeasons.kt
@@ -18,17 +18,6 @@ class GetAnimeWithEpisodesAndSeasons(
     private val getSeasonsByAnimeId: GetSeasonsByAnimeId,
 ) {
 
-    private fun isHierarchicalSupported(sourceId: Long): Boolean {
-        return try {
-            val extensionManager = uy.kohesive.injekt.Injekt.get<eu.kanade.tachiyomi.extension.ExtensionManager>()
-            val installedExtensions = extensionManager.installedExtensionsFlow.value
-            val extension = installedExtensions.find { ext -> ext.sources.any { it.id == sourceId } }
-            (extension?.libVersion ?: 0.0) >= 16.0
-        } catch (e: Exception) {
-            false
-        }
-    }
-
     suspend fun subscribe(
         id: Long,
         applyScanlatorFilter: Boolean = false,
@@ -36,13 +25,10 @@ class GetAnimeWithEpisodesAndSeasons(
         virtualSeasonsFlow: Flow<List<Anime>>? = null,
     ): Flow<Triple<Anime, List<Episode>, List<SeasonAnime>>> {
         return animeRepository.getAnimeByIdAsFlow(id).flatMapLatest { anime ->
-            val isHierarchicalSupported = isHierarchicalSupported(anime.source)
-            val effectiveHierarchical = useHierarchicalSeasons && isHierarchicalSupported
-            
-            val parentId = if (effectiveHierarchical) (anime.parentId ?: id) else id
+            val parentId = if (useHierarchicalSeasons) (anime.parentId ?: id) else id
             
             val dbSeasonsFlow = animeRepository.getAnimeSeasonsByIdAsFlow(parentId)
-            val seasonsListFlow = getSeasonsByAnimeId.subscribe(id, virtualSeasonsFlow, effectiveHierarchical)
+            val seasonsListFlow = getSeasonsByAnimeId.subscribe(id, virtualSeasonsFlow, useHierarchicalSeasons)
 
             val combinedSeasonsFlow = combine(dbSeasonsFlow, seasonsListFlow) { dbSeasons, seasonsList ->
                 seasonsList.map { season ->
@@ -84,12 +70,9 @@ class GetAnimeWithEpisodesAndSeasons(
 
     suspend fun awaitSeasons(id: Long, useHierarchicalSeasons: Boolean = true): List<SeasonAnime> {
         val anime = animeRepository.getAnimeById(id)
-        val isHierarchicalSupported = isHierarchicalSupported(anime.source)
-        val effectiveHierarchical = useHierarchicalSeasons && isHierarchicalSupported
-        
-        val parentId = if (effectiveHierarchical) (anime.parentId ?: id) else id
+        val parentId = if (useHierarchicalSeasons) (anime.parentId ?: id) else id
         val dbSeasons = animeRepository.getAnimeSeasonsById(parentId)
-        val seasonsList = getSeasonsByAnimeId.await(id, emptyList(), effectiveHierarchical)
+        val seasonsList = getSeasonsByAnimeId.await(id, emptyList(), useHierarchicalSeasons)
 
         return seasonsList.map { season ->
             val dbSeason = dbSeasons.find { it.anime.id == season.anime.id }

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/GetSeasonsByAnimeId.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/GetSeasonsByAnimeId.kt
@@ -15,13 +15,19 @@ class GetSeasonsByAnimeId(
     private val animeMergeRepository: AnimeMergeRepository,
 ) {
 
-    suspend fun await(animeId: Long, virtualSeasons: List<Anime> = emptyList()): List<Season> {
+    suspend fun await(
+        animeId: Long, 
+        virtualSeasons: List<Anime> = emptyList(),
+        useHierarchicalSeasons: Boolean = true,
+    ): List<Season> {
         val anime = animeRepository.getAnimeById(animeId) ?: return emptyList()
         
         // 1. Get real hierarchical seasons from DB
-        val dbSeasons = animeRepository.getAnimeSeasonsById(anime.parentId ?: anime.id).map { it.anime }
-        if (dbSeasons.isNotEmpty()) {
-            return dbSeasons.map {
+        val parentId = if (useHierarchicalSeasons) (anime.parentId ?: anime.id) else anime.id
+        val dbSeasons = animeRepository.getAnimeSeasonsById(parentId).map { it.anime }
+        val pool = (listOf(anime) + dbSeasons).distinctBy { it.id }
+        if (pool.size > 1) {
+            return pool.map {
                 Season(
                     anime = it,
                     seasonNumber = it.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
@@ -39,7 +45,7 @@ class GetSeasonsByAnimeId(
                 Season(
                     anime = mergedAnime,
                     seasonNumber = mergedAnime.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, mergedAnime.title),
-                    isPrimary = ref?.isInfoAnime ?: false
+                    isPrimary = ref?.isInfoAnime ?: (mergedAnime.id == anime.id)
                 )
             }.sortedBy { it.seasonNumber }
         }
@@ -60,9 +66,13 @@ class GetSeasonsByAnimeId(
         return listOf(Season(anime, SeasonRecognition.parseSeasonNumber(anime.title, anime.title), true))
     }
 
-    fun subscribe(animeId: Long, virtualSeasonsFlow: Flow<List<Anime>>? = null): Flow<List<Season>> = flow {
+    fun subscribe(
+        animeId: Long, 
+        virtualSeasonsFlow: Flow<List<Anime>>? = null,
+        useHierarchicalSeasons: Boolean = true,
+    ): Flow<List<Season>> = flow {
         val anime = animeRepository.getAnimeById(animeId) ?: return@flow
-        val parentId = anime.parentId ?: anime.id
+        val parentId = if (useHierarchicalSeasons) (anime.parentId ?: anime.id) else anime.id
         
         val animeFlow = animeRepository.getAnimeByIdAsFlow(animeId)
         val dbSeasonsFlow = animeRepository.getAnimeSeasonsByIdAsFlow(parentId)
@@ -90,9 +100,12 @@ class GetSeasonsByAnimeId(
     ): List<Season> {
         if (anime == null) return emptyList()
         
+        // Always ensure the current anime is part of the pool
+        val pool = (listOf(anime) + dbSeasons).distinctBy { it.id }
+
         // 1. Prioritize Hierarchical Seasons
-        if (dbSeasons.isNotEmpty()) {
-            return dbSeasons.map {
+        if (pool.size > 1) {
+            return pool.map {
                 Season(
                     anime = it,
                     seasonNumber = it.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
@@ -108,7 +121,7 @@ class GetSeasonsByAnimeId(
                 Season(
                     anime = mergedAnime,
                     seasonNumber = mergedAnime.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, mergedAnime.title),
-                    isPrimary = ref?.isInfoAnime ?: false
+                    isPrimary = ref?.isInfoAnime ?: (mergedAnime.id == anime.id)
                 )
             }.sortedBy { it.seasonNumber }
         }

--- a/domain/src/main/java/tachiyomi/domain/anime/interactor/GetSeasonsByAnimeId.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/interactor/GetSeasonsByAnimeId.kt
@@ -30,7 +30,8 @@ class GetSeasonsByAnimeId(
             return pool.map {
                 Season(
                     anime = it,
-                    seasonNumber = it.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
+                    seasonNumber = it.seasonNumber.takeIf { num -> num != null && num != 0.0 }
+                        ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
                     isPrimary = it.id == anime.id
                 )
             }.sortedBy { it.seasonNumber }
@@ -56,7 +57,8 @@ class GetSeasonsByAnimeId(
             return all.map { 
                 Season(
                     anime = it,
-                    seasonNumber = it.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
+                    seasonNumber = it.seasonNumber.takeIf { num -> num != null && num != 0.0 }
+                        ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
                     isPrimary = it.id == anime.id
                 )
             }.sortedBy { it.seasonNumber }
@@ -108,7 +110,8 @@ class GetSeasonsByAnimeId(
             return pool.map {
                 Season(
                     anime = it,
-                    seasonNumber = it.seasonNumber ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
+                    seasonNumber = it.seasonNumber.takeIf { num -> num != null && num != 0.0 }
+                        ?: SeasonRecognition.parseSeasonNumber(anime.title, it.title),
                     isPrimary = it.id == anime.id
                 )
             }.sortedBy { it.seasonNumber }

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -12,12 +12,12 @@ object SeasonRecognition {
     /**
      * Ordinal support: 2nd season, 3rd season, etc.
      */
-    private val ordinals = Regex("""(\d+)(?:st|nd|rd|th)\s+(?:season|part|cour|volume|arc|chapter)""", RegexOption.IGNORE_CASE)
+    private val ordinals = Regex("""(\d+)(?:st|nd|rd|th)\s+(?:season|part|cour|volume|arc|chapter|year|semester)""", RegexOption.IGNORE_CASE)
 
     /**
      * Part support: Part 1, Part 2
      */
-    private val parts = Regex("""(?<=\bpart) *$NUMBER_PATTERN""", RegexOption.IGNORE_CASE)
+    private val parts = Regex("""(?<=\bpart|semester|cour) *$NUMBER_PATTERN""", RegexOption.IGNORE_CASE)
 
     /**
      * Format tags support
@@ -186,9 +186,9 @@ object SeasonRecognition {
             .replace(Regex("""(?i)\s+\(?(?:TV|OAV|OVA|ONA|Special|Movie|BD|Remux)\)?.*"""), "")
             .replace(Regex("""(?i)\s*\[(?:1080p|720p|480p|BD|DVD|Web|Eng-Sub|Softsubs)\]"""), "")
             // 2. Remove explicit season/part keywords and everything after them
-            .replace(Regex("""(?i)\s*[:\-\–\—]?\s*(?:Season|S|Part|Cour|Vol|Volume|Chapter|Arc)\s*(?:\d+|I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX).*"""), "")
-            .replace(Regex("""(?i)\s*\d+(?:st|nd|rd|th)\s+(?:Season|Part|Cour|Volume|Arc|Chapter).*"""), "")
-            .replace(Regex("""(?i)\s*(?:First|Second|Third|Fourth|Fifth|Sixth|Seventh|Eighth|Ninth|Tenth)\s+(?:Season|Part|Cour|Volume|Arc|Chapter).*"""), "")
+            .replace(Regex("""(?i)\s*[:\-\–\—]?\s*(?:Season|S|Part|Cour|Vol|Volume|Chapter|Arc|Year|Semester)\s*(?:\d+|I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX).*"""), "")
+            .replace(Regex("""(?i)\s*\d+(?:st|nd|rd|th)\s+(?:Season|Part|Cour|Volume|Arc|Chapter|Year|Semester).*"""), "")
+            .replace(Regex("""(?i)\s*(?:First|Second|Third|Fourth|Fifth|Sixth|Seventh|Eighth|Ninth|Tenth)\s+(?:Season|Part|Cour|Volume|Arc|Chapter|Year|Semester).*"""), "")
             // 3. Remove Roman numeral + Subtitle combos (e.g. "Mushoku Tensei II: Jobless...")
             .replace(Regex("""\s+(?:II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)\s*[:\-\–\—].*""", RegexOption.IGNORE_CASE), "")
             // 4. Remove bare numbers (2-10) or Roman numerals (II-XX) at the very end
@@ -231,10 +231,14 @@ object SeasonRecognition {
 
         // Try to find Season
         ordinals.find(matchingContext)?.let { 
-            if (it.value.contains("season", ignoreCase = true)) {
-                season = it.groups[1]?.value?.toDoubleOrNull()
-            } else if (it.value.contains("part", ignoreCase = true) || it.value.contains("cour", ignoreCase = true)) {
-                part = it.groups[1]?.value?.toDoubleOrNull()
+            val matchedText = it.value.lowercase()
+            when {
+                matchedText.contains("season") || matchedText.contains("year") -> {
+                    season = it.groups[1]?.value?.toDoubleOrNull()
+                }
+                matchedText.contains("part") || matchedText.contains("cour") || matchedText.contains("semester") -> {
+                    part = it.groups[1]?.value?.toDoubleOrNull()
+                }
             }
         }
 
@@ -264,7 +268,8 @@ object SeasonRecognition {
             textOrdinals.findAll(matchingContext).forEach { match ->
                 val word = match.groups[1]?.value?.lowercase()
                 val value = textOrdinalMap[word] ?: 1.0
-                if (match.value.contains("season", ignoreCase = true)) {
+                val matchedText = match.value.lowercase()
+                if (matchedText.contains("season") || matchedText.contains("year")) {
                     if (season == null) season = value
                 } else {
                     if (part == null) part = value

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -225,18 +225,59 @@ object SeasonRecognition {
         
         matchingContext = matchingContext.replace(Regex("""\b\d{3,4}p?\b"""), "").trim()
 
-        // 2. Try Explicit Detection
-        ordinals.find(matchingContext)?.let { return it.groups[1]?.value?.toDoubleOrNull() ?: 1.0 }
-        parts.find(matchingContext)?.let { return getSeasonNumberFromMatch(it) }
-        textOrdinals.find(matchingContext)?.let { 
-            val word = it.groups[1]?.value?.lowercase()
-            return textOrdinalMap[word] ?: 1.0
+        // 2. Dual-Layer Detection (Season + Part)
+        var season: Double? = null
+        var part: Double? = null
+
+        // Try to find Season
+        ordinals.find(matchingContext)?.let { 
+            if (it.value.contains("season", ignoreCase = true)) {
+                season = it.groups[1]?.value?.toDoubleOrNull()
+            } else if (it.value.contains("part", ignoreCase = true) || it.value.contains("cour", ignoreCase = true)) {
+                part = it.groups[1]?.value?.toDoubleOrNull()
+            }
         }
-        romanNumerals.find(matchingContext)?.let {
-            val roman = it.groups[1]?.value?.uppercase()
-            return romanMap[roman] ?: -1.0
+
+        if (season == null) {
+            basic.find(matchingContext)?.let { 
+                season = it.groups[1]?.value?.toDoubleOrNull()
+            }
         }
-        basic.find(matchingContext)?.let { return getSeasonNumberFromMatch(it) }
+
+        // Try to find Part if not already found via ordinals
+        if (part == null) {
+            parts.find(matchingContext)?.let {
+                part = it.groups[1]?.value?.toDoubleOrNull()
+            }
+        }
+
+        // Roman Numerals fallback for Season
+        if (season == null) {
+            romanNumerals.find(matchingContext)?.let {
+                val roman = it.groups[1]?.value?.uppercase()
+                season = romanMap[roman]
+            }
+        }
+
+        // Handle text ordinals
+        if (season == null || part == null) {
+            textOrdinals.findAll(matchingContext).forEach { match ->
+                val word = match.groups[1]?.value?.lowercase()
+                val value = textOrdinalMap[word] ?: 1.0
+                if (match.value.contains("season", ignoreCase = true)) {
+                    if (season == null) season = value
+                } else {
+                    if (part == null) part = value
+                }
+            }
+        }
+
+        // Combine Season and Part
+        if (season != null || part != null) {
+            val s = season ?: 1.0 // Default to Season 1 if only Part is found
+            val p = (part ?: 0.0) / 100.0
+            return s + p
+        }
 
         // 3. Format tags
         if (cleanSeasonName.contains(Regex("""\b(?:movie|film|theatrical)\b""", RegexOption.IGNORE_CASE))) return -2.0

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -215,8 +215,39 @@ object SeasonRecognition {
         return cleaned
     }
 
+    private val acronymMap = mapOf(
+        "mt" to "mushoku tensei",
+        "cote" to "classroom of the elite",
+        "aot" to "attack on titan",
+        "sao" to "sword art online",
+        "danmachi" to "is it wrong to try to pick up girls in a dungeon",
+        "ten-sura" to "that time i got reincarnated as a slime",
+        "slime" to "that time i got reincarnated as a slime"
+    )
+
+    fun isAcronymMatch(query: String, candidate: String): Boolean {
+        val q = query.lowercase().trim()
+        val c = candidate.lowercase().trim()
+        
+        // 1. Predefined map
+        if (acronymMap[q]?.let { c.contains(it) } == true) return true
+        if (acronymMap[c]?.let { q.contains(it) } == true) return true
+
+        // 2. Generate acronym from candidate
+        val generated = c.split(" ", "-", ":")
+            .filter { it.length > 1 }
+            .mapNotNull { it.firstOrNull() }
+            .joinToString("")
+        
+        return generated == q
+    }
+
     fun getAlphanumeric(title: String): String {
-        return title.lowercase().replace(Regex("""[^a-z0-9]"""), "")
+        return title.lowercase()
+            .replace(Regex("""\bno\.\s*"""), "")
+            .replace(Regex("""#\s*"""), "")
+            .replace(Regex("""number\s*"""), "")
+            .replace(Regex("""[^a-z0-9]"""), "")
     }
 
     fun parseSeasonNumber(animeTitle: String, seasonName: String, existingNumber: Double? = null): Double {
@@ -228,6 +259,9 @@ object SeasonRecognition {
         
         // 1. Identification Check (BEFORE stripping tags)
         val rawLower = seasonName.lowercase()
+            .replace(Regex("""\bno\.\s*"""), "#")
+            .replace(Regex("""\bnumber\s*"""), "#")
+
         val formatTagValue = when {
             rawLower.contains(Regex("""\b(?:movie|film|theatrical)\b""")) -> -2.0
             rawLower.contains(Regex("""\b(?:ova|oav)\b""")) -> -3.0
@@ -259,7 +293,7 @@ object SeasonRecognition {
         var season: Double? = null
         var part: Double? = null
 
-        // Try to find Season
+        // Try to find Season (Priority)
         ordinals.find(matchingContext)?.let { 
             val matchedText = it.value.lowercase()
             when {
@@ -330,23 +364,23 @@ object SeasonRecognition {
             return 99.0
         }
 
-        // 4. Strict Identity Logic (Normalization)
+        // 5. Strict Identity Logic (Normalization)
         val rootAlpha = getAlphanumeric(rootTitle)
         val candidateAlpha = getAlphanumeric(seasonName)
         
-        if (rootAlpha == candidateAlpha) {
+        if (rootAlpha == candidateAlpha && rootAlpha.isNotEmpty()) {
             return 1.0
         }
 
-        // 5. Number Extraction from context
-        if (matchingContext.isNotEmpty()) {
+        // 6. Number Extraction from context (Only if root title is matched)
+        if (matchingContext.isNotEmpty() && candidateAlpha.contains(rootAlpha)) {
             val numberInSubtitle = number.find(matchingContext)
             if (numberInSubtitle != null) {
                 return getSeasonNumberFromMatch(numberInSubtitle)
             }
         }
 
-        // 6. No number found? It's a related Special/Side-story, not Season 2.
+        // 7. No number found? It's a related Special/Side-story, not Season 2.
         return -5.0
     }
 

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -231,16 +231,15 @@ object SeasonRecognition {
         if (generated == q) return true
 
         // 3. Fallback to substring matching on signature-based acronym
-        val (short, long) = if (query.length < candidate.length) query to candidate else candidate to query
+        val (short, long) = if (q.length < c.length) q to c else c to q
         if (short.length < 2 || short.any { it.isWhitespace() }) return false
         
         val acronym = getSignatureWords(long)
             .sortedBy { long.indexOf(it) } // Keep original order
             .mapNotNull { it.firstOrNull() }
             .joinToString("")
-            .lowercase()
             
-        return acronym.contains(short.lowercase())
+        return acronym.contains(short)
     }
 
     fun getAlphanumeric(title: String): String {

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -99,21 +99,7 @@ object SeasonRecognition {
         return diceCoefficient(sig1, sig2)
     }
 
-    /**
-     * Checks if one title is an acronym of the other (e.g. "MT" vs "Mushoku Tensei")
-     */
-    fun isAcronymMatch(original: String, candidate: String): Boolean {
-        val (short, long) = if (original.length < candidate.length) original to candidate else candidate to original
-        if (short.length < 2 || short.any { it.isWhitespace() }) return false
-        
-        val acronym = getSignatureWords(long)
-            .sortedBy { long.indexOf(it) } // Keep original order
-            .mapNotNull { it.firstOrNull() }
-            .joinToString("")
-            .lowercase()
-            
-        return acronym.contains(short.lowercase())
-    }
+
 
     fun diceCoefficient(s1: String, s2: String): Double {
         val str1 = s1.lowercase().replace(Regex("""\s+"""), "")
@@ -225,6 +211,9 @@ object SeasonRecognition {
         "slime" to "that time i got reincarnated as a slime"
     )
 
+    /**
+     * Checks if one title is an acronym of the other (e.g. "MT" vs "Mushoku Tensei")
+     */
     fun isAcronymMatch(query: String, candidate: String): Boolean {
         val q = query.lowercase().trim()
         val c = candidate.lowercase().trim()
@@ -239,7 +228,19 @@ object SeasonRecognition {
             .mapNotNull { it.firstOrNull() }
             .joinToString("")
         
-        return generated == q
+        if (generated == q) return true
+
+        // 3. Fallback to substring matching on signature-based acronym
+        val (short, long) = if (query.length < candidate.length) query to candidate else candidate to query
+        if (short.length < 2 || short.any { it.isWhitespace() }) return false
+        
+        val acronym = getSignatureWords(long)
+            .sortedBy { long.indexOf(it) } // Keep original order
+            .mapNotNull { it.firstOrNull() }
+            .joinToString("")
+            .lowercase()
+            
+        return acronym.contains(short.lowercase())
     }
 
     fun getAlphanumeric(title: String): String {

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -12,12 +12,26 @@ object SeasonRecognition {
     /**
      * Ordinal support: 2nd season, 3rd season, etc.
      */
-    private val ordinals = Regex("""(\d+)(?:st|nd|rd|th)\s+(?:season|part|cour|volume|arc|chapter|year|semester)""", RegexOption.IGNORE_CASE)
+    private val ordinals = Regex("""(\d+)(?:st|nd|rd|th)\s+(?:season|part|cour|volume|arc|chapter|year|semester|piece)""", RegexOption.IGNORE_CASE)
 
     /**
      * Part support: Part 1, Part 2
      */
-    private val parts = Regex("""(?<=\bpart|semester|cour) *$NUMBER_PATTERN""", RegexOption.IGNORE_CASE)
+    private val parts = Regex("""(?<=\bpart|semester|cour|piece|chapter) *$NUMBER_PATTERN""", RegexOption.IGNORE_CASE)
+
+    /**
+     * Japanese Part indicators
+     */
+    private val jpParts = mapOf(
+        "zenpen" to 0.1, // First Part
+        "chuuhen" to 0.2, // Middle Part
+        "kouhen" to 0.3, // Last Part
+        "zen" to 0.1,
+        "kou" to 0.3,
+        "1st cour" to 0.1,
+        "2nd cour" to 0.2
+    )
+    private val jpPartsRegex = Regex("""\b(?:zenpen|chuuhen|kouhen|zen|kou|1st cour|2nd cour)\b""", RegexOption.IGNORE_CASE)
 
     /**
      * Format tags support
@@ -181,22 +195,28 @@ object SeasonRecognition {
     }
 
     fun getRootTitle(title: String): String {
-        return title
+        val cleaned = title
             // 1. Remove common tags and extra info first (e.g. "(TV)", "[BD]")
             .replace(Regex("""(?i)\s+\(?(?:TV|OAV|OVA|ONA|Special|Movie|BD|Remux)\)?.*"""), "")
             .replace(Regex("""(?i)\s*\[(?:1080p|720p|480p|BD|DVD|Web|Eng-Sub|Softsubs)\]"""), "")
             // 2. Remove explicit season/part keywords and everything after them
-            .replace(Regex("""(?i)\s*[:\-\–\—]?\s*(?:Season|S|Part|Cour|Vol|Volume|Chapter|Arc|Year|Semester)\s*(?:\d+|I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX).*"""), "")
-            .replace(Regex("""(?i)\s*\d+(?:st|nd|rd|th)\s+(?:Season|Part|Cour|Volume|Arc|Chapter|Year|Semester).*"""), "")
-            .replace(Regex("""(?i)\s*(?:First|Second|Third|Fourth|Fifth|Sixth|Seventh|Eighth|Ninth|Tenth)\s+(?:Season|Part|Cour|Volume|Arc|Chapter|Year|Semester).*"""), "")
+            .replace(Regex("""(?i)\s*[:\-\–\—]?\s*(?:Season|S|Part|Cour|Vol|Volume|Chapter|Arc|Year|Semester|Piece)\s*(?:\d+|I|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX).*"""), "")
+            .replace(Regex("""(?i)\s*\d+(?:st|nd|rd|th)\s+(?:Season|Part|Cour|Volume|Arc|Chapter|Year|Semester|Piece).*"""), "")
+            .replace(Regex("""(?i)\s*(?:First|Second|Third|Fourth|Fifth|Sixth|Seventh|Eighth|Ninth|Tenth)\s+(?:Season|Part|Cour|Volume|Arc|Chapter|Year|Semester|Piece).*"""), "")
             // 3. Remove Roman numeral + Subtitle combos (e.g. "Mushoku Tensei II: Jobless...")
             .replace(Regex("""\s+(?:II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)\s*[:\-\–\—].*""", RegexOption.IGNORE_CASE), "")
             // 4. Remove bare numbers (2-10) or Roman numerals (II-XX) at the very end
             .replace(Regex("""\s+(?:[2-9]|10|II|III|IV|V|VI|VII|VIII|IX|X|XI|XII|XIII|XIV|XV|XVI|XVII|XVIII|XIX|XX)$""", RegexOption.IGNORE_CASE), "")
-            // 5. Special handling for "Final" to avoid titles like "Final Fantasy"
+            // 5. Special handling for "Final"
             .replace(Regex("""(?i)\s+(?:Final\s+Season|Final\s+Part|The\s+Final\s+Season|The\s+Final\s+Part|Conclusion|Ending)$"""), "")
             .replace(Regex("""\s+"""), " ")
             .trim()
+            
+        return cleaned
+    }
+
+    fun getAlphanumeric(title: String): String {
+        return title.lowercase().replace(Regex("""[^a-z0-9]"""), "")
     }
 
     fun parseSeasonNumber(animeTitle: String, seasonName: String, existingNumber: Double? = null): Double {
@@ -236,7 +256,7 @@ object SeasonRecognition {
                 matchedText.contains("season") || matchedText.contains("year") -> {
                     season = it.groups[1]?.value?.toDoubleOrNull()
                 }
-                matchedText.contains("part") || matchedText.contains("cour") || matchedText.contains("semester") -> {
+                matchedText.contains("part") || matchedText.contains("cour") || matchedText.contains("semester") || matchedText.contains("piece") -> {
                     part = it.groups[1]?.value?.toDoubleOrNull()
                 }
             }
@@ -252,6 +272,13 @@ object SeasonRecognition {
         if (part == null) {
             parts.find(matchingContext)?.let {
                 part = it.groups[1]?.value?.toDoubleOrNull()
+            }
+        }
+
+        // Japanese Parts fallback
+        if (part == null) {
+            jpPartsRegex.find(cleanSeasonName)?.let {
+                part = jpParts[it.value.lowercase()]?.times(10.0)
             }
         }
 
@@ -296,16 +323,16 @@ object SeasonRecognition {
             return 99.0
         }
 
-        // 4. Strict Identity Logic
-        val fullRoot = rootTitle.lowercase().replace(Regex("""[^a-z0-9]"""), "")
-        val fullCandidate = seasonName.lowercase().replace(Regex("""[^a-z0-9]"""), "")
+        // 4. Strict Identity Logic (Normalization)
+        val rootAlpha = getAlphanumeric(rootTitle)
+        val candidateAlpha = getAlphanumeric(seasonName)
         
-        if (fullRoot == fullCandidate) {
+        if (rootAlpha == candidateAlpha) {
             return 1.0
         }
 
         // 5. Number Extraction from context
-        if (matchingContext.length > 1) {
+        if (matchingContext.isNotEmpty()) {
             val numberInSubtitle = number.find(matchingContext)
             if (numberInSubtitle != null) {
                 return getSeasonNumberFromMatch(numberInSubtitle)

--- a/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/anime/service/SeasonRecognition.kt
@@ -226,8 +226,18 @@ object SeasonRecognition {
 
         val rootTitle = getRootTitle(animeTitle)
         
-        // 1. Clean name for matching
-        var cleanSeasonName = seasonName.lowercase()
+        // 1. Identification Check (BEFORE stripping tags)
+        val rawLower = seasonName.lowercase()
+        val formatTagValue = when {
+            rawLower.contains(Regex("""\b(?:movie|film|theatrical)\b""")) -> -2.0
+            rawLower.contains(Regex("""\b(?:ova|oav)\b""")) -> -3.0
+            rawLower.contains(Regex("""\b(?:ona)\b""")) -> -4.0
+            rawLower.contains(Regex("""\b(?:special|omake|extra|recap|summary|reawakening|re-awakening|preview)\b""")) -> -5.0
+            else -> null
+        }
+
+        // 2. Clean name for matching
+        var cleanSeasonName = rawLower
             .replace(Regex("""(?i)\s*\[(?:1080p|720p|480p|BD|DVD|Web|Eng-Sub|Softsubs)\]"""), "")
             .replace(Regex("""(?i)\s+\(?(?:TV|OAV|OVA|ONA|Special|Movie|BD|Remux)\)?.*"""), "")
             .trim()
@@ -245,7 +255,7 @@ object SeasonRecognition {
         
         matchingContext = matchingContext.replace(Regex("""\b\d{3,4}p?\b"""), "").trim()
 
-        // 2. Dual-Layer Detection (Season + Part)
+        // 3. Dual-Layer Detection (Season + Part)
         var season: Double? = null
         var part: Double? = null
 
@@ -311,11 +321,8 @@ object SeasonRecognition {
             return s + p
         }
 
-        // 3. Format tags
-        if (cleanSeasonName.contains(Regex("""\b(?:movie|film|theatrical)\b""", RegexOption.IGNORE_CASE))) return -2.0
-        if (cleanSeasonName.contains(Regex("""\b(?:ova|oav)\b""", RegexOption.IGNORE_CASE))) return -3.0
-        if (cleanSeasonName.contains(Regex("""\b(?:ona)\b""", RegexOption.IGNORE_CASE))) return -4.0
-        if (cleanSeasonName.contains(Regex("""\b(?:special|omake|extra|recap|summary|reawakening|re-awakening|preview)\b""", RegexOption.IGNORE_CASE))) return -5.0
+        // 4. Return format tag if found earlier
+        if (formatTagValue != null) return formatTagValue
         
         // Final check anchored to "Season" or "Part"
         if (cleanSeasonName.contains(Regex("""(?i)final\s+(?:season|part|chapter)""")) || 

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -354,6 +354,8 @@ class LibraryPreferences(
     }
     // <-- AY
 
+    fun relationTitleLanguage() = preferenceStore.getString("pref_relation_title_language", "english")
+
     companion object {
         const val DEVICE_ONLY_ON_WIFI = "wifi"
         const val DEVICE_NETWORK_NOT_METERED = "network_not_metered"

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1666,4 +1666,6 @@
     <string name="romaji">Romaji</string>
     <string name="english">English</string>
     <string name="native_title">Native</string>
+    <string name="relation_prequel">Prequel</string>
+    <string name="relation_sequel">Sequel</string>
 </resources>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="display_mode_season">Season %1$s</string>
+    <string name="display_mode_season_part">Season %1$s Part %2$s</string>
     <!-- Generic strings -->
     <string name="on">On</string>
     <string name="off">Off</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1660,4 +1660,10 @@
     <string name="pref_skip_filler_episodes">Skip Filler Episodes</string>
     <string name="pref_skip_filler_episodes_summary">Skip filler episodes detected by this feature</string>
     <string name="player_filler_skipped">Filler episode skipped</string>
+    <!-- Anime relations -->
+    <string name="pref_anime_relations">Anime relations</string>
+    <string name="pref_relation_title_language">Preferred title for Prequel &amp; Sequel</string>
+    <string name="romaji">Romaji</string>
+    <string name="english">English</string>
+    <string name="native_title">Native</string>
 </resources>


### PR DESCRIPTION
## Description
This PR introduces support for viewing Anime relations (Prequels and Sequels) directly from the AniList API, alongside a new setting for customizing the preferred title language (Romaji, English, or Native) for these relation chips.

### Key Changes:
- **Prequel/Sequel UI:** Added `PrequelSequelBox.kt` to parse and beautifully display related anime in the Anime detail screen.
- **Title Language Preferences:** Introduced new localization settings allowing users to pick their preferred language for relation titles (Romaji, English, or Native).
- **Data Layer Updates:** Added `ALRelationResult` DTO and updated `AnilistApi.kt` / `Anilist.kt` to fetch and map relational data appropriately.
- **Settings Integration:** Plumbed the new Title Language toggle into the Library Settings screen (`SettingsLibraryScreen.kt` and `LibraryPreferences.kt`).

### Motivation
To improve the binge-watching and discovery experience by making it effortless to find chronological watch orders without leaving the app, while respecting the user's localized title preferences.