### PR TITLE
fix issue with sibnet and all hoster that doesn't accept HEAD request

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -788,7 +788,7 @@ class Downloader(
         if (size <= 0) {
             try {
                 client.newCall(Request.Builder().url(video.videoUrl).headers(headers).head().build()).execute().use { res ->
-                    size = if (res.isSuccessful) res.header("Content-Length")?.toLong() ?: -1L else -1L
+                    size = if (res.isSuccessful) res.header("Content-Length")?.toLongOrNull() ?: -1L else -1L
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.DEBUG) { "HEAD request failed: ${e.message}" }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -788,7 +788,7 @@ class Downloader(
         if (size <= 0) {
             try {
                 client.newCall(Request.Builder().url(video.videoUrl).headers(headers).head().build()).execute().use { res ->
-                    size = res.header("Content-Length")?.toLong() ?: -1L
+                    size = if (res.isSuccessful) res.header("Content-Length")?.toLong() ?: -1L else -1L
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.DEBUG) { "HEAD request failed: ${e.message}" }


### PR DESCRIPTION
resolve an issue when the HEAD request send to calculate the file size was rejected

Previously, no verification was performed.
Consequently, if the server rejected the request (e.g., with a 400 error),
the downloader used the response body size, likely an error message, as the video file size.
Now, by implementing a simple if (res.isSuccessful) check, if the server returns a 400 error, the fallback mechanism using the Content-Range header is triggered

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.

  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/salmanbappi/AniZen/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
