### PR TITLE
discord rich presence

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPC.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPC.kt
@@ -25,11 +25,11 @@ class DiscordRPC(val token: String, val status: String) {
      * @param since the activity start time.
      */
     suspend fun updateRPC(
-        activity: Activity,
+        activity: Activity?,
         since: Long? = null,
     ) {
         rpc = Presence(
-            activities = listOf(activity),
+            activities = if (activity != null) listOf(activity) else emptyList(),
             afk = true,
             since = since,
             status = status,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPCModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPCModels.kt
@@ -161,6 +161,7 @@ data class PlayerData(
     val thumbnailUrl: String? = null,
     val startTimestamp: Long? = null,
     val endTimestamp: Long? = null,
+    val isPaused: Boolean = false,
 )
 
 data class ReaderData(
@@ -179,27 +180,28 @@ enum class DiscordScreen(
     val imageUrl: String,
 ) {
     APP(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
-    LIBRARY(R.string.label_library, R.string.discord_status_browsing, LIBRARY_IMAGE_URL),
-    UPDATES(R.string.label_recent_updates, R.string.discord_status_scrolling, UPDATES_IMAGE_URL),
-    HISTORY(R.string.label_recent_manga, R.string.discord_status_scrolling, HISTORY_IMAGE_URL),
-    BROWSE(R.string.label_sources, R.string.discord_status_browsing, BROWSE_IMAGE_URL),
-    MORE(R.string.label_settings, R.string.discord_status_messing, MORE_IMAGE_URL),
-    WEBVIEW(R.string.action_web_view, R.string.discord_status_browsing, WEBVIEW_IMAGE_URL),
+    LIBRARY(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
+    UPDATES(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
+    HISTORY(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
+    BROWSE(R.string.label_sources, R.string.discord_status_exploring, ANIMETAIL_IMAGE),
+    MORE(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
+    WEBVIEW(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
+    DETAILS(R.string.app_name, R.string.discord_status_using, ANIMETAIL_IMAGE),
     VIDEO(R.string.video, R.string.watching, VIDEO_IMAGE_URL),
     MANGA(R.string.manga, R.string.reading, MANGA_IMAGE_URL),
 }
 
 // Constants for standard Rich Presence image urls
-private const val ANIZEN_LOGO_IMAGE_URL = "https://raw.githubusercontent.com/salmanbappi/AniZen/preview/app/src/main/res/drawable/ic_splash_logo_raw.png"
+private const val ANIZEN_LOGO_IMAGE_URL = "https://raw.githubusercontent.com/salmanbappi/AniZen/preview/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
 private const val ANIMETAIL_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
 private const val ANIMETAIL_PREVIEW_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
 private val ANIMETAIL_IMAGE = if (isPreviewBuildType) ANIMETAIL_PREVIEW_IMAGE_URL else ANIMETAIL_IMAGE_URL
-private const val LIBRARY_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
-private const val UPDATES_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
-private const val HISTORY_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
-private const val BROWSE_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
-private const val MORE_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
-private const val WEBVIEW_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
+private const val BROWSE_IMAGE_URL = "https://raw.githubusercontent.com/google/material-design-icons/master/png/action/explore/materialicons/48dp/1x/baseline_explore_white_48dp.png"
+private const val LIBRARY_IMAGE_URL = "https://raw.githubusercontent.com/google/material-design-icons/master/png/av/video_library/materialicons/48dp/1x/baseline_video_library_white_48dp.png"
+private const val UPDATES_IMAGE_URL = "https://raw.githubusercontent.com/google/material-design-icons/master/png/navigation/refresh/materialicons/48dp/1x/baseline_refresh_white_48dp.png"
+private const val HISTORY_IMAGE_URL = "https://raw.githubusercontent.com/google/material-design-icons/master/png/action/history/materialicons/48dp/1x/baseline_history_white_48dp.png"
+private const val MORE_IMAGE_URL = "https://raw.githubusercontent.com/google/material-design-icons/master/png/action/settings/materialicons/48dp/1x/baseline_settings_white_48dp.png"
+private const val WEBVIEW_IMAGE_URL = "https://raw.githubusercontent.com/google/material-design-icons/master/png/action/language/materialicons/48dp/1x/baseline_language_white_48dp.png"
 private const val VIDEO_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
 private const val MANGA_IMAGE_URL = ANIZEN_LOGO_IMAGE_URL
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPCService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPCService.kt
@@ -52,11 +52,7 @@ class DiscordRPCService : Service() {
         if (rpc != null) {
             launchIO {
                 try {
-                    if (lastUsedScreen == DiscordScreen.VIDEO) {
-                        setAnimeScreen(this@DiscordRPCService, lastUsedScreen)
-                    } else if (lastUsedScreen == DiscordScreen.MANGA) {
-                        setMangaScreen(this@DiscordRPCService, lastUsedScreen)
-                    }
+                    setAnimeScreen(this@DiscordRPCService, lastUsedScreen)
                 } catch (e: Exception) {
                     Log.e(TAG, "Error setting screen: ${e.message}", e)
                 }
@@ -148,22 +144,87 @@ class DiscordRPCService : Service() {
         }
         private const val TAG = "DiscordRPCService"
 
+        private var lastCustomDetails: String? = null
+        private var lastCustomState: String? = null
+        private var lastPlayerData: PlayerData? = null
+        private var isIncognitoActive: Boolean = false
+
+        private fun isIncognitoModeActive(incognitoMode: Boolean = false): Boolean {
+            val basePreferences: eu.kanade.domain.base.BasePreferences by injectLazy()
+            val isGlobalIncognito = basePreferences.incognitoMode().get()
+            val isDiscordIncognito = connectionsPreferences.discordRPCIncognito().get()
+            return isGlobalIncognito || isDiscordIncognito || incognitoMode
+        }
+
         internal suspend fun setAnimeScreen(
             context: Context,
             discordScreen: DiscordScreen,
+            customDetails: String? = null,
+            customState: String? = null,
             playerData: PlayerData = PlayerData(),
+            smallImageUri: String? = null,
         ) {
-            if (discordScreen != DiscordScreen.VIDEO) return
-            lastUsedScreen = discordScreen // Update last used screen
+            if (isIncognitoModeActive(playerData.incognitoMode)) {
+                if (!isIncognitoActive) {
+                    isIncognitoActive = true
+                    rpc?.updateRPC(null)
+                }
+                return
+            }
+            isIncognitoActive = false
+
+            if (discordScreen == lastUsedScreen &&
+                customDetails == lastCustomDetails &&
+                customState == lastCustomState &&
+                playerData == lastPlayerData
+            ) {
+                return
+            }
+
+            lastUsedScreen = discordScreen
+            lastCustomDetails = customDetails
+            lastCustomState = customState
+            lastPlayerData = playerData
 
             if (rpc == null) return
-            updateDiscordRPC(context, playerData, discordScreen)
+
+            if (discordScreen == DiscordScreen.VIDEO) {
+                updateDiscordRPC(
+                    context = context,
+                    playerData = playerData,
+                    discordScreen = discordScreen,
+                    customDetails = customDetails,
+                    customState = customState,
+                    largeImageUri = playerData.thumbnailUrl,
+                    smallImageUri = smallImageUri ?: DiscordScreen.APP.imageUrl,
+                )
+            } else {
+                withIOContext {
+                    val rpcExternalAsset = getRPCExternalAsset()
+                    val appLogoUri = getDiscordThumbnail(rpcExternalAsset, DiscordScreen.APP.imageUrl, false)
+
+                    updateDiscordRPC(
+                        context = context,
+                        playerData = playerData,
+                        discordScreen = discordScreen,
+                        customDetails = customDetails,
+                        customState = customState,
+                        largeImageUri = appLogoUri,
+                        smallImageUri = null,
+                    )
+                }
+            }
         }
+
         private suspend fun updateDiscordRPC(
             context: Context,
             playerData: PlayerData,
             discordScreen: DiscordScreen,
             sinceTime: Long = since,
+            customDetails: String? = null,
+            customState: String? = null,
+            largeImageUri: String? = null,
+            smallImageUri: String? = null,
         ) {
             val appName = context.getString(R.string.app_name)
 
@@ -174,22 +235,32 @@ class DiscordRPCService : Service() {
             val showDownloadButton = connectionsPreferences.discordShowDownloadButton().get()
             val showDiscordButton = connectionsPreferences.discordShowDiscordButton().get()
 
-            val name = playerData.animeTitle ?: appName
+            val name = when (discordScreen) {
+                DiscordScreen.VIDEO -> playerData.animeTitle ?: appName
+                else -> appName
+            }
+
             val details = when {
+                customDetails != null -> customDetails
                 customMessage.isNotBlank() -> customMessage
-                playerData.animeTitle != null -> playerData.animeTitle
+                discordScreen == DiscordScreen.VIDEO -> playerData.animeTitle ?: appName
                 else -> context.getString(discordScreen.details)
             }
 
             val state = when {
-                !showProgress -> null
-                playerData.episodeNumber != null -> playerData.episodeNumber
-                else -> context.getString(discordScreen.text)
+                customState != null -> customState
+                discordScreen == DiscordScreen.VIDEO && showProgress -> playerData.episodeNumber
+                else -> null
             }
 
-            val imageUrl = playerData.thumbnailUrl ?: discordScreen.imageUrl
+            val finalLargeImage = largeImageUri ?: playerData.thumbnailUrl ?: DiscordScreen.APP.imageUrl
+            val finalSmallImage = if (discordScreen == DiscordScreen.VIDEO) {
+                smallImageUri ?: DiscordScreen.APP.imageUrl
+            } else {
+                null
+            }
 
-            val timestamps = if (showTimestamp) {
+            val timestamps = if (showTimestamp && !playerData.isPaused && discordScreen == DiscordScreen.VIDEO) {
                 Activity.Timestamps(
                     start = playerData.startTimestamp ?: since,
                     end = playerData.endTimestamp,
@@ -225,8 +296,8 @@ class DiscordRPCService : Service() {
                     type = 3,
                     timestamps = timestamps,
                     assets = Activity.Assets(
-                        largeImage = imageUrl.fixDiscordImage(),
-                        smallImage = DiscordScreen.APP.imageUrl.fixDiscordImage(),
+                        largeImage = finalLargeImage.fixDiscordImage(),
+                        smallImage = finalSmallImage?.fixDiscordImage(),
                         smallText = context.getString(DiscordScreen.APP.text),
                     ),
                     buttons = buttons,
@@ -241,9 +312,13 @@ class DiscordRPCService : Service() {
             discordScreen: DiscordScreen,
             readerData: ReaderData = ReaderData(),
         ) {
-            lastUsedScreen = discordScreen // Update last used screen
-            if (rpc == null) return
-            updateDiscordRPC(context, readerData, discordScreen)
+            if (discordScreen == DiscordScreen.MANGA) {
+                lastUsedScreen = discordScreen // Update last used screen
+                if (rpc == null) return
+                updateDiscordRPC(context, readerData, discordScreen)
+            } else {
+                setAnimeScreen(context, discordScreen)
+            }
         }
 
         private suspend fun updateDiscordRPC(
@@ -302,7 +377,45 @@ class DiscordRPCService : Service() {
 
         private fun String.fixDiscordImage(): String {
             if (this.startsWith(MP_PREFIX)) return this
+            if (this.startsWith(EXTERNAL_PREFIX)) return "$MP_PREFIX$this"
+            if (this.startsWith("https://")) return "${MP_PREFIX}${EXTERNAL_PREFIX}https/${this.removePrefix("https://")}"
+            if (this.startsWith("http://")) return "${MP_PREFIX}${EXTERNAL_PREFIX}http/${this.removePrefix("http://")}"
             return "$MP_PREFIX$this"
+        }
+
+        @Suppress("SwallowedException", "TooGenericExceptionCaught")
+        internal suspend fun setAnimeDetailsActivity(
+            context: Context,
+            animeTitle: String?,
+            thumbnailUrl: String?,
+            animeId: Long? = null,
+        ) {
+            if (rpc == null || animeTitle == null) return
+            try {
+                val categories = if (animeId != null) getCategories(animeId) else emptyList()
+                val discordIncognito = isIncognito(categories, false)
+
+                val displayTitle = animeTitle.takeUnless { discordIncognito }
+                val displayThumbnail = if (discordIncognito) null else thumbnailUrl
+
+                withIOContext {
+                    val rpcExternalAsset = getRPCExternalAsset()
+                    val animeThumbnail = getDiscordThumbnail(rpcExternalAsset, displayThumbnail, discordIncognito)
+                    val appLogoUri = getDiscordThumbnail(rpcExternalAsset, DiscordScreen.APP.imageUrl, false)
+
+                    setAnimeScreen(
+                        context = context,
+                        discordScreen = DiscordScreen.DETAILS,
+                        playerData = PlayerData(
+                            animeTitle = displayTitle,
+                            thumbnailUrl = animeThumbnail,
+                        ),
+                        smallImageUri = appLogoUri,
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error setting anime details activity: ${e.message}", e)
+            }
         }
 
         @Suppress("SwallowedException", "TooGenericExceptionCaught", "CyclomaticComplexMethod")
@@ -324,6 +437,8 @@ class DiscordRPCService : Service() {
                     val rpcExternalAsset = getRPCExternalAsset() // Get RPCExternalAsset
                     val animeThumbnail =
                         getDiscordThumbnail(rpcExternalAsset, playerData.thumbnailUrl, discordIncognito)
+                    val appLogoUri =
+                        getDiscordThumbnail(rpcExternalAsset, DiscordScreen.APP.imageUrl, false)
 
                     setAnimeScreen(
                         context = context,
@@ -334,7 +449,9 @@ class DiscordRPCService : Service() {
                             thumbnailUrl = animeThumbnail,
                             startTimestamp = startTime,
                             endTimestamp = end,
+                            isPaused = playerData.isPaused,
                         ),
+                        smallImageUri = appLogoUri,
                     )
                 }
             } catch (e: Exception) {
@@ -392,14 +509,7 @@ class DiscordRPCService : Service() {
         }
 
         private fun getFormattedEpisodeNumber(playerData: PlayerData, discordIncognito: Boolean): String? {
-            return playerData.episodeNumber?.let {
-                when {
-                    discordIncognito -> null
-                    connectionsPreferences.useChapterTitles().get() -> it
-                    ceil(it.toDouble()) == floor(it.toDouble()) -> "Episode ${it.toInt()}"
-                    else -> "Episode $it"
-                }
-            }
+            return playerData.episodeNumber?.takeUnless { discordIncognito }
         }
         private fun getFormattedChapterNumber(readerData: ReaderData, discordIncognito: Boolean): String? {
             val chapterNumber = readerData.chapterNumber

--- a/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordWebsocket.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordWebsocket.kt
@@ -59,6 +59,7 @@ open class DiscordWebSocketImpl(
         get() = SupervisorJob() + Dispatchers.IO
 
     private fun sendIdentify() {
+        log("Sending IDENTIFY (op: 2) with token: $token")
         val response = Identity.Response(
             op = 2,
             d = Identity(
@@ -72,7 +73,9 @@ open class DiscordWebSocketImpl(
                 intents = 0,
             ),
         )
-        webSocket?.send(json.encodeToString(response))
+        val payload = json.encodeToString(response)
+        log("IDENTIFY Payload: $payload")
+        webSocket?.send(payload)
     }
 
     @Suppress("MagicNumber")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/RPCExternalAsset.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/RPCExternalAsset.kt
@@ -30,8 +30,15 @@ class RPCExternalAsset(
     )
 
     private val api = "https://discord.com/api/v9/applications/$applicationId/external-assets"
+
+    companion object {
+        private val cache = java.util.concurrent.ConcurrentHashMap<String, String>()
+    }
+
     suspend fun getDiscordUri(imageUrl: String): String? {
         if (imageUrl.startsWith("mp:")) return imageUrl
+        cache[imageUrl]?.let { return it }
+
         val request = Request.Builder().url(api).header("Authorization", token)
             .post("{\"urls\":[\"$imageUrl\"]}".toRequestBody("application/json".toMediaType()))
             .build()
@@ -39,6 +46,7 @@ class RPCExternalAsset(
             val res = client.newCall(request).await()
             json.decodeFromString<List<ExternalAsset>>(res.body.string())
                 .firstOrNull()?.externalAssetPath?.let { "mp:$it" }
+                ?.also { cache[imageUrl] = it }
         }.getOrNull()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/AnimeScreen.kt
@@ -36,7 +36,10 @@ import eu.kanade.presentation.anime.DuplicateAnimeDialog
 import eu.kanade.presentation.anime.EditCoverAction
 import eu.kanade.presentation.anime.EpisodeOptionsDialogScreen
 import eu.kanade.presentation.anime.EpisodeSettingsDialog
+import eu.kanade.domain.connections.service.ConnectionsPreferences
 import eu.kanade.presentation.anime.components.AnimeCoverDialog
+import eu.kanade.tachiyomi.data.connections.discord.DiscordRPCService
+import uy.kohesive.injekt.injectLazy
 import eu.kanade.presentation.anime.components.ClearAnimeDialog
 import eu.kanade.presentation.anime.components.DeleteEpisodesDialog
 import eu.kanade.presentation.anime.components.SetIntervalDialog
@@ -137,7 +140,15 @@ class AnimeScreen(
             }
         }
 
-        LaunchedEffect(successState.anime, screenModel.source) {            if (isHttpSource) {
+        LaunchedEffect(successState.anime, screenModel.source) {
+            val connectionsPreferences: ConnectionsPreferences by injectLazy()
+            if (connectionsPreferences.enableDiscordRPC().get()) {
+                DiscordRPCService.setAnimeScreen(
+                    context = context,
+                    discordScreen = eu.kanade.tachiyomi.data.connections.discord.DiscordScreen.APP,
+                )
+            }
+            if (isHttpSource) {
                 try {
                     withIOContext {
                         assistUrl = getAnimeUrl(screenModel.anime, screenModel.source)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -145,7 +145,6 @@ data object BrowseTab : Tab {
             (context as? MainActivity)?.ready = true
             // AM (DISCORD) -->
             DiscordRPCService.setAnimeScreen(context, DiscordScreen.BROWSE)
-            DiscordRPCService.setMangaScreen(context, DiscordScreen.BROWSE)
             // <-- AM (DISCORD)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -38,6 +38,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import eu.kanade.domain.connections.service.ConnectionsPreferences
+import eu.kanade.tachiyomi.data.connections.discord.DiscordRPCService
+import eu.kanade.tachiyomi.data.connections.discord.DiscordScreen
+import uy.kohesive.injekt.injectLazy
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -134,6 +138,19 @@ data class BrowseSourceScreen(
         val haptic = LocalHapticFeedback.current
         val uriHandler = LocalUriHandler.current
         val snackbarHostState = remember { SnackbarHostState() }
+
+        val context = LocalContext.current
+
+        LaunchedEffect(screenModel.source) {
+            val connectionsPreferences: ConnectionsPreferences by injectLazy()
+            if (connectionsPreferences.enableDiscordRPC().get()) {
+                DiscordRPCService.setAnimeScreen(
+                    context = context,
+                    discordScreen = DiscordScreen.BROWSE,
+                    customState = screenModel.source.name,
+                )
+            }
+        }
 
         val onHelpClick = { uriHandler.openUri(LocalAnimeSource.HELP_URL) }
         val onWebViewClick = f@{

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -179,8 +179,7 @@ data object HistoryTab : Tab {
         }
 
         LaunchedEffect(Unit) {
-            DiscordRPCService.setAnimeScreen(context, DiscordScreen.HISTORY)
-            DiscordRPCService.setMangaScreen(context, DiscordScreen.HISTORY)
+            DiscordRPCService.setAnimeScreen(context, DiscordScreen.APP)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -546,7 +546,7 @@ data object LibraryTab : Tab {
             if (!state.isLoading) {
                 (context as? MainActivity)?.ready = true
                 // AM (DISCORD) -->
-                DiscordRPCService.setAnimeScreen(context, DiscordScreen.LIBRARY)
+                DiscordRPCService.setAnimeScreen(context, DiscordScreen.APP)
                 // <-- AM (DISCORD)
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -279,8 +279,19 @@ class MainActivity : BaseActivity() {
                         .onEach {
                             DiscordRPCService.stop(this@MainActivity.applicationContext, 0L)
                             DiscordRPCService.start(this@MainActivity.applicationContext)
-                            DiscordRPCService.setAnimeScreen(this@MainActivity, DiscordScreen.MORE)
-                            DiscordRPCService.setMangaScreen(this@MainActivity, DiscordScreen.MORE)
+                            DiscordRPCService.setAnimeScreen(this@MainActivity, DiscordScreen.APP)
+                        }.launchIn(this)
+
+                    preferences.incognitoMode().changes()
+                        .drop(1)
+                        .onEach {
+                            DiscordRPCService.setAnimeScreen(this@MainActivity, DiscordRPCService.lastUsedScreen)
+                        }.launchIn(this)
+
+                    connectionsPreferences.discordRPCIncognito().changes()
+                        .drop(1)
+                        .onEach {
+                            DiscordRPCService.setAnimeScreen(this@MainActivity, DiscordRPCService.lastUsedScreen)
                         }.launchIn(this)
                     // <-- AM (DISCORD)
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
@@ -105,8 +105,7 @@ data object MoreTab : Tab {
         LaunchedEffect(Unit) {
             (context as? MainActivity)?.ready = true
             // AM (DISCORD) -->
-            DiscordRPCService.setAnimeScreen(context, DiscordScreen.MORE)
-            DiscordRPCService.setMangaScreen(context, DiscordScreen.MORE)
+            DiscordRPCService.setAnimeScreen(context, DiscordScreen.APP)
             // <-- AM (DISCORD)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1569,16 +1569,25 @@ class PlayerActivity : BaseActivity() {
                 if (!exitingPlayer) {
                     val anime = viewModel.currentAnime.value ?: return@launchIO
                     val episode = viewModel.currentEpisode.value ?: return@launchIO
-                    val currentPosition = viewModel.pos.value.toLong() * 1000
-                    val duration = player.duration?.toLong()?.times(1000) ?: 1440000L
+                    val isPaused = player.paused == true
 
-                    val startTimestamp = Calendar.getInstance().apply {
-                        timeInMillis = System.currentTimeMillis() - currentPosition
+                    val (startTime, endTime) = if (isPaused) {
+                        Pair(null, null)
+                    } else {
+                        val currentPosition = viewModel.pos.value.toLong() * 1000
+                        val duration = player.duration?.toLong()?.times(1000) ?: 1440000L
+
+                        val startTimestamp = Calendar.getInstance().apply {
+                            timeInMillis = System.currentTimeMillis() - currentPosition
+                        }
+                        val endTimestamp = Calendar.getInstance().apply {
+                            timeInMillis = startTimestamp.timeInMillis
+                            add(Calendar.MILLISECOND, duration.toInt())
+                        }
+                        Pair(startTimestamp.timeInMillis, endTimestamp.timeInMillis)
                     }
-                    val endTimestamp = Calendar.getInstance().apply {
-                        timeInMillis = startTimestamp.timeInMillis
-                        add(Calendar.MILLISECOND, duration.toInt())
-                    }
+
+                    val formattedEpisodeNumber = episode.name
 
                     DiscordRPCService.setPlayerActivity(
                         context = this@PlayerActivity,
@@ -1587,13 +1596,10 @@ class PlayerActivity : BaseActivity() {
                             animeId = anime.id,
                             animeTitle = anime.ogTitle,
                             thumbnailUrl = anime.thumbnailUrl ?: "",
-                            episodeNumber = if (connectionsPreferences.useChapterTitles().get()) {
-                                episode.name
-                            } else {
-                                episode.episode_number.toString()
-                            },
-                            startTimestamp = startTimestamp.timeInMillis,
-                            endTimestamp = endTimestamp.timeInMillis,
+                            episodeNumber = formattedEpisodeNumber,
+                            startTimestamp = startTime,
+                            endTimestamp = endTime,
+                            isPaused = isPaused,
                         ),
                     )
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/connections/DiscordLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/connections/DiscordLoginActivity.kt
@@ -38,14 +38,38 @@ class DiscordLoginActivity : BaseActivity() {
 
         webView.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
-                if (url != null && url.endsWith("/app")) {
+                if (url != null && url.contains("/channels/")) {
                     webView.stopLoading()
                     webView.evaluateJavascript(
                         """
                         (function() {
-                            const wreq = (webpackChunkdiscord_app.push([[''], {}, e => { m = []; for (let c in e.c) m.push(e.c[c])}]), m)
-                            webpackChunkdiscord_app.pop()
-                            const token = wreq.find(m => m?.exports?.default?.getToken !== void 0).exports.default.getToken();
+                            let token = null;
+                            webpackChunkdiscord_app.push([
+                                [Symbol()],
+                                {},
+                                (req) => {
+                                    for (const id in req.c) {
+                                        const exports = req.c[id]?.exports;
+                                        if (!exports) continue;
+                                        for (const key in exports) {
+                                            if (exports[key]?.getToken && typeof exports[key].getToken === 'function') {
+                                                const t = exports[key].getToken();
+                                                if (t && typeof t === 'string') {
+                                                    token = t;
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                        if (exports.getToken && typeof exports.getToken === 'function') {
+                                            const t = exports.getToken();
+                                            if (t && typeof t === 'string') {
+                                                token = t;
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }
+                            ]);
                             return token;
                         })()
                         """.trimIndent(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -143,8 +143,7 @@ data object UpdatesTab : Tab {
         }
 
         LaunchedEffect(Unit) {
-            DiscordRPCService.setAnimeScreen(context, DiscordScreen.UPDATES)
-            DiscordRPCService.setMangaScreen(context, DiscordScreen.UPDATES)
+            DiscordRPCService.setAnimeScreen(context, DiscordScreen.APP)
         }
 
         DisposableEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/webview/WebViewActivity.kt
@@ -85,7 +85,6 @@ class WebViewActivity : BaseActivity() {
         // AM (DISCORD) -->
         lifecycleScope.launchIO {
             DiscordRPCService.setAnimeScreen(this@WebViewActivity, DiscordScreen.WEBVIEW)
-            DiscordRPCService.setMangaScreen(this@WebViewActivity, DiscordScreen.WEBVIEW)
         }
         // <-- AM (DISCORD)
     }
@@ -94,7 +93,6 @@ class WebViewActivity : BaseActivity() {
     override fun onDestroy() {
         lifecycleScope.launchIO {
             DiscordRPCService.setAnimeScreen(this@WebViewActivity, DiscordRPCService.lastUsedScreen)
-            DiscordRPCService.setMangaScreen(this@WebViewActivity, DiscordRPCService.lastUsedScreen)
         }
         super.onDestroy()
     }

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -199,6 +199,11 @@
     <string name="discord_status_description">%1$s %2$s</string>
     <string name="discord_status_using">Using</string>
     <string name="discord_status_browsing">Browsing</string>
+    <string name="discord_status_exploring">Exploring</string>
+    <string name="discord_status_checking">Checking</string>
+    <string name="discord_status_reviewing">Reviewing</string>
+    <string name="discord_status_configuring">Configuring</string>
+    <string name="discord_status_details">Viewing details of</string>
     <string name="discord_status_scrolling">Scrolling through</string>
     <string name="discord_status_messing">Messing around with</string>
     <string name="discord_download_button">Read on %s</string>

--- a/i18n-kmk/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/fr/strings.xml
@@ -129,4 +129,15 @@
     <string name="custom_theme_palette_bubblegum">Bubblegum</string>
     <string name="custom_theme_palette_springfield">Springfield</string>
     <string name="pref_library_filter_categories_details">Les entrées dans les catégories exclues ne seront pas affichées, même si elles se trouvent également dans les catégories incluses.</string>
+
+    <!-- Discord section -->
+    <string name="discord_status_using">Utilise</string>
+    <string name="discord_status_browsing">Parcourt</string>
+    <string name="discord_status_exploring">Explore</string>
+    <string name="discord_status_checking">Consulte</string>
+    <string name="discord_status_reviewing">Revoit</string>
+    <string name="discord_status_configuring">Configure</string>
+    <string name="discord_status_details">Consulte la fiche de</string>
+    <string name="discord_status_scrolling">Fait défiler</string>
+    <string name="discord_status_messing">Dans les réglages de</string>
 </resources>


### PR DESCRIPTION
fixed discord presence by using a js injection that will not stop working after an update

updated the different status possible with fixed images and a progress bar that stop when the user use pause

here is some possible situations:

<img width="294" height="158" alt="Capture d&#39;écran_20260809_152757" src="https://github.com/user-attachments/assets/7bb4ea1b-f0b8-4bed-b9dd-36ac47f42c36" />
<img width="294" height="158" alt="Capture d&#39;écran_20260809_152813" src="https://github.com/user-attachments/assets/2ac8c553-3ad1-47ed-a1a3-077303ca49fa" />
<img width="294" height="158" alt="Capture d&#39;écran_20260809_152825" src="https://github.com/user-attachments/assets/7da174ca-655a-4fdc-a394-4ef79c34ad56" />
<img width="294" height="158" alt="Capture d&#39;écran_20260809_152843" src="https://github.com/user-attachments/assets/006caa89-d011-4b91-8eae-8fec1fd189e2" />
<img width="294" height="158" alt="Capture d&#39;écran_20260809_152849" src="https://github.com/user-attachments/assets/742618c9-67c5-4254-8d9e-a0297e1feead" />

it's important to not create too many different possible status because discord can only change 5 times every 20 seconds

oh and btw i've removed the mention to setMangaScreen since anizen doesn't support manga

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/salmanbappi/AniZen/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
